### PR TITLE
Use more efficient QString constructor

### DIFF
--- a/src/autotype/AutoType.cpp
+++ b/src/autotype/AutoType.cpp
@@ -267,7 +267,7 @@ void AutoType::executeAutoTypeActions(const Entry* entry,
 
     if (!error.isEmpty()) {
         auto errorMsg = tr("The requested Auto-Type sequence cannot be used due to an error:");
-        errorMsg.append(QString("\n%1\n%2").arg(sequence, error));
+        errorMsg.append(QStringLiteral("\n%1\n%2").arg(sequence, error));
         if (getMainWindow()) {
             MessageBox::critical(getMainWindow(), tr("Auto-Type Error"), errorMsg);
         }

--- a/src/autotype/test/AutoTypeTest.cpp
+++ b/src/autotype/test/AutoTypeTest.cpp
@@ -24,7 +24,7 @@ bool AutoTypePlatformTest::isAvailable()
 
 QString AutoTypePlatformTest::keyToString(Qt::Key key)
 {
-    return QString("[Key0x%1]").arg(key, 0, 16);
+    return QStringLiteral("[Key0x%1]").arg(key, 0, 16);
 }
 
 QStringList AutoTypePlatformTest::windowTitles()

--- a/src/browser/BrowserEntrySaveDialog.cpp
+++ b/src/browser/BrowserEntrySaveDialog.cpp
@@ -32,7 +32,7 @@ BrowserEntrySaveDialog::BrowserEntrySaveDialog(QWidget* parent)
     connect(m_ui->cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
 
     m_ui->itemsList->setSelectionMode(QAbstractItemView::SingleSelection);
-    m_ui->label->setText(QString(tr("You have multiple databases open.\n"
+    m_ui->label->setText(QStringLiteral(tr("You have multiple databases open.\n"
                                     "Please select the correct database for saving credentials.")));
 }
 
@@ -55,7 +55,7 @@ int BrowserEntrySaveDialog::setItems(QList<DatabaseWidget*>& databaseWidgets, Da
         if (databaseName == databaseFileName) {
             item->setText(databaseFileName);
         } else {
-            item->setText(QString("%1 (%2)").arg(databaseName, databaseFileName));
+            item->setText(QStringLiteral("%1 (%2)").arg(databaseName, databaseFileName));
         }
 
         if (currentWidget == dbWidget) {

--- a/src/browser/BrowserService.cpp
+++ b/src/browser/BrowserService.cpp
@@ -596,7 +596,7 @@ QString BrowserService::storeKey(const QString& key)
 
     hideWindow();
     db->metadata()->customData()->set(CustomData::BrowserKeyPrefix + id, key);
-    db->metadata()->customData()->set(QString("%1_%2").arg(CustomData::Created, id),
+    db->metadata()->customData()->set(QStringLiteral("%1_%2").arg(CustomData::Created, id),
                                       QLocale::system().toString(Clock::currentDateTime(), QLocale::ShortFormat));
     return id;
 }
@@ -1585,7 +1585,7 @@ void BrowserService::databaseLocked(DatabaseWidget* dbWidget)
 {
     if (dbWidget) {
         QJsonObject msg;
-        msg["action"] = QString("database-locked");
+        msg["action"] = QStringLiteral("database-locked");
         m_browserHost->broadcastClientMessage(msg);
     }
 }
@@ -1599,7 +1599,7 @@ void BrowserService::databaseUnlocked(DatabaseWidget* dbWidget)
         }
 
         QJsonObject msg;
-        msg["action"] = QString("database-unlocked");
+        msg["action"] = QStringLiteral("database-unlocked");
         m_browserHost->broadcastClientMessage(msg);
     }
 }

--- a/src/browser/BrowserSettingsWidget.cpp
+++ b/src/browser/BrowserSettingsWidget.cpp
@@ -212,7 +212,7 @@ void BrowserSettingsWidget::validateProxyLocation()
             if (!QFile::exists(resolveCustomProxyLocation())) {
                 StateColorPalette statePalette;
                 auto color = statePalette.color(StateColorPalette::ColorRole::Error);
-                m_ui->customProxyLocation->setStyleSheet(QString("QLineEdit { background: %1; }").arg(color.name()));
+                m_ui->customProxyLocation->setStyleSheet(QStringLiteral("QLineEdit { background: %1; }").arg(color.name()));
                 m_ui->customProxyLocation->setToolTip(tr("The custom proxy location does not exist."));
 
                 m_ui->messageWidget->showMessage(tr("<b>Error:</b> The custom proxy location does not exist. Correct "
@@ -283,9 +283,9 @@ void BrowserSettingsWidget::saveSettings()
 void BrowserSettingsWidget::showProxyLocationFileDialog()
 {
 #ifdef Q_OS_WIN
-    QString fileTypeFilter(QString("%1 (*.exe);;%2 (*.*)").arg(tr("Executable Files"), tr("All Files")));
+    QString fileTypeFilter(QStringLiteral("%1 (*.exe);;%2 (*.*)").arg(tr("Executable Files"), tr("All Files")));
 #else
-    QString fileTypeFilter(QString("%1 (*)").arg(tr("Executable Files")));
+    QString fileTypeFilter(QStringLiteral("%1 (*)").arg(tr("Executable Files")));
 #endif
 
     auto initialFilePath = resolveCustomProxyLocation();

--- a/src/browser/NativeMessageInstaller.cpp
+++ b/src/browser/NativeMessageInstaller.cpp
@@ -237,7 +237,7 @@ QString NativeMessageInstaller::getNativeMessagePath(SupportedBrowsers browser) 
     basePath = QDir::homePath();
 #endif
     if (browser == SupportedBrowsers::CUSTOM) {
-        return QString("%1/%2.json").arg(getTargetPath(browser), HOST_NAME);
+        return QStringLiteral("%1/%2.json").arg(getTargetPath(browser), HOST_NAME);
     }
 
     return QStringLiteral("%1%2/%3.json").arg(basePath, getTargetPath(browser), HOST_NAME);
@@ -335,7 +335,7 @@ QJsonObject NativeMessageInstaller::constructFile(SupportedBrowsers browser)
 #ifdef QT_DEBUG
         auto customId = browserSettings()->customExtensionId();
         if (!customId.isEmpty()) {
-            arr.append(QString("chrome-extension://%1/").arg(customId));
+            arr.append(QStringLiteral("chrome-extension://%1/").arg(customId));
         }
 #endif
         script["allowed_origins"] = arr;

--- a/src/browser/PasskeyUtils.cpp
+++ b/src/browser/PasskeyUtils.cpp
@@ -224,7 +224,7 @@ bool PasskeyUtils::isRegistrableDomainSuffix(const QString& hostSuffixString, co
         return false;
     }
 
-    const auto prefixedHostSuffix = QString(".%1").arg(hostSuffix);
+    const auto prefixedHostSuffix = QStringLiteral(".%1").arg(hostSuffix);
     if (!originalHost.endsWith(prefixedHostSuffix)) {
         return false;
     }
@@ -242,7 +242,7 @@ bool PasskeyUtils::isRegistrableDomainSuffix(const QString& hostSuffixString, co
         return false;
     }
 
-    if (!hostSuffix.endsWith(QString(".%1").arg(originalPublicSuffix))) {
+    if (!hostSuffix.endsWith(QStringLiteral(".%1").arg(originalPublicSuffix))) {
         return false;
     }
 
@@ -329,7 +329,7 @@ QJsonObject PasskeyUtils::buildClientDataJson(const QJsonObject& publicKey, cons
     clientData["challenge"] = publicKey["challenge"];
     clientData["crossOrigin"] = false;
     clientData["origin"] = origin;
-    clientData["type"] = get ? QString("webauthn.get") : QString("webauthn.create");
+    clientData["type"] = get ? QStringLiteral("webauthn.get") : QStringLiteral("webauthn.create");
 
     return clientData;
 }

--- a/src/cli/Add.cpp
+++ b/src/cli/Add.cpp
@@ -47,13 +47,13 @@ const QCommandLineOption Add::GenerateOption = QCommandLineOption(QStringList() 
 
 Add::Add()
 {
-    name = QString("add");
+    name = QStringLiteral("add");
     description = QObject::tr("Add a new entry to a database.");
     options.append(Add::UsernameOption);
     options.append(Add::UrlOption);
     options.append(Add::NotesOption);
     options.append(Add::PasswordPromptOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to add."), QString("")});
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Path of the entry to add."), QString()});
 
     // Password generation options.
     options.append(Add::GenerateOption);

--- a/src/cli/AddGroup.cpp
+++ b/src/cli/AddGroup.cpp
@@ -25,9 +25,9 @@
 
 AddGroup::AddGroup()
 {
-    name = QString("mkdir");
+    name = QStringLiteral("mkdir");
     description = QObject::tr("Adds a new group to a database.");
-    positionalArguments.append({QString("group"), QObject::tr("Path of the group to add."), QString("")});
+    positionalArguments.append({QStringLiteral("group"), QObject::tr("Path of the group to add."), QString()});
 }
 
 AddGroup::~AddGroup() = default;

--- a/src/cli/Analyze.cpp
+++ b/src/cli/Analyze.cpp
@@ -39,7 +39,7 @@ const QCommandLineOption Analyze::OkonOption =
 
 Analyze::Analyze()
 {
-    name = QString("analyze");
+    name = QStringLiteral("analyze");
     description = QObject::tr("Analyze passwords for weaknesses and problems.");
     options.append(Analyze::HIBPDatabaseOption);
     options.append(Analyze::OkonOption);

--- a/src/cli/AttachmentExport.cpp
+++ b/src/cli/AttachmentExport.cpp
@@ -29,15 +29,15 @@ const QCommandLineOption AttachmentExport::StdoutOption =
 
 AttachmentExport::AttachmentExport()
 {
-    name = QString("attachment-export");
+    name = QStringLiteral("attachment-export");
     description = QObject::tr("Export an attachment of an entry.");
     options.append(AttachmentExport::StdoutOption);
     positionalArguments.append(
-        {QString("entry"), QObject::tr("Path of the entry with the target attachment."), QString("")});
+        {QStringLiteral("entry"), QObject::tr("Path of the entry with the target attachment."), QString()});
     positionalArguments.append(
-        {QString("attachment-name"), QObject::tr("Name of the attachment to be exported."), QString("")});
+        {QStringLiteral("attachment-name"), QObject::tr("Name of the attachment to be exported."), QString()});
     optionalArguments.append(
-        {QString("export-file"), QObject::tr("Path to which the attachment should be exported."), QString("")});
+        {QStringLiteral("export-file"), QObject::tr("Path to which the attachment should be exported."), QString()});
 }
 
 int AttachmentExport::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/AttachmentImport.cpp
+++ b/src/cli/AttachmentImport.cpp
@@ -31,14 +31,14 @@ const QCommandLineOption AttachmentImport::ForceOption =
 
 AttachmentImport::AttachmentImport()
 {
-    name = QString("attachment-import");
+    name = QStringLiteral("attachment-import");
     description = QObject::tr("Imports an attachment to an entry.");
     options.append(AttachmentImport::ForceOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry."), QString("")});
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Path of the entry."), QString()});
     positionalArguments.append(
-        {QString("attachment-name"), QObject::tr("Name of the attachment to be added."), QString("")});
+        {QStringLiteral("attachment-name"), QObject::tr("Name of the attachment to be added."), QString()});
     positionalArguments.append(
-        {QString("import-file"), QObject::tr("Path of the attachment to be imported."), QString("")});
+        {QStringLiteral("import-file"), QObject::tr("Path of the attachment to be imported."), QString()});
 }
 
 int AttachmentImport::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/AttachmentRemove.cpp
+++ b/src/cli/AttachmentRemove.cpp
@@ -25,11 +25,11 @@
 
 AttachmentRemove::AttachmentRemove()
 {
-    name = QString("attachment-rm");
+    name = QStringLiteral("attachment-rm");
     description = QObject::tr("Remove an attachment of an entry.");
     positionalArguments.append(
-        {QString("entry"), QObject::tr("Path of the entry with the target attachment."), QString("")});
-    positionalArguments.append({QString("name"), QObject::tr("Name of the attachment to be removed."), QString("")});
+        {QStringLiteral("entry"), QObject::tr("Path of the entry with the target attachment."), QString()});
+    positionalArguments.append({QStringLiteral("name"), QObject::tr("Name of the attachment to be removed."), QString()});
 }
 
 int AttachmentRemove::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Clip.cpp
+++ b/src/cli/Clip.cpp
@@ -46,18 +46,18 @@ const QCommandLineOption Clip::BestMatchOption =
 
 Clip::Clip()
 {
-    name = QString("clip");
+    name = QStringLiteral("clip");
     description = QObject::tr("Copy an entry's attribute to the clipboard.");
     options.append(Clip::AttributeOption);
     options.append(Clip::TotpOption);
     options.append(Clip::BestMatchOption);
     positionalArguments.append(
-        {QString("entry"), QObject::tr("Path of the entry to clip.", "clip = copy to clipboard"), QString("")});
+        {QStringLiteral("entry"), QObject::tr("Path of the entry to clip.", "clip = copy to clipboard"), QString()});
     optionalArguments.append(
-        {QString("timeout"),
+        {QStringLiteral("timeout"),
          QObject::tr("Timeout before clearing the clipboard (default is %1 seconds, set to 0 for unlimited).")
              .arg(CLI_DEFAULT_CLIP_TIMEOUT),
-         QString("[timeout]")});
+         QStringLiteral("[timeout]")});
 }
 
 int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)
@@ -81,7 +81,7 @@ int Clip::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<
     if (parser->isSet(Clip::BestMatchOption)) {
         EntrySearcher searcher;
         const auto& searchTerm = args.at(1);
-        const auto results = searcher.search(QString("title:%1").arg(searchTerm), database->rootGroup(), true);
+        const auto results = searcher.search(QStringLiteral("title:%1").arg(searchTerm), database->rootGroup(), true);
         if (results.count() > 1) {
             err << QObject::tr("Multiple entries matching:") << Qt::endl;
             for (const Entry* result : results) {

--- a/src/cli/Close.cpp
+++ b/src/cli/Close.cpp
@@ -19,7 +19,7 @@
 
 Close::Close()
 {
-    name = QString("close");
+    name = QStringLiteral("close");
     description = QObject::tr("Close the currently opened database.");
 }
 

--- a/src/cli/DatabaseCommand.cpp
+++ b/src/cli/DatabaseCommand.cpp
@@ -24,7 +24,7 @@
 
 DatabaseCommand::DatabaseCommand()
 {
-    positionalArguments.append({QString("database"), QObject::tr("Path of the database."), QString("")});
+    positionalArguments.append({QStringLiteral("database"), QObject::tr("Path of the database."), QString()});
     options.append(Command::KeyFileOption);
     options.append(Command::NoPasswordOption);
 #ifdef WITH_XC_YUBIKEY

--- a/src/cli/DatabaseCreate.cpp
+++ b/src/cli/DatabaseCreate.cpp
@@ -47,9 +47,9 @@ const QCommandLineOption DatabaseCreate::SetPasswordOption =
 
 DatabaseCreate::DatabaseCreate()
 {
-    name = QString("db-create");
+    name = QStringLiteral("db-create");
     description = QObject::tr("Create a new database.");
-    positionalArguments.append({QString("database"), QObject::tr("Path of the database."), QString("")});
+    positionalArguments.append({QStringLiteral("database"), QObject::tr("Path of the database."), QString()});
     options.append(DatabaseCreate::SetKeyFileOption);
     options.append(DatabaseCreate::SetKeyFileShortOption);
     options.append(DatabaseCreate::SetPasswordOption);

--- a/src/cli/DatabaseEdit.cpp
+++ b/src/cli/DatabaseEdit.cpp
@@ -34,7 +34,7 @@ const QCommandLineOption DatabaseEdit::UnsetKeyFileOption =
 
 DatabaseEdit::DatabaseEdit()
 {
-    name = QString("db-edit");
+    name = QStringLiteral("db-edit");
     description = QObject::tr("Edit a database.");
     options.append(DatabaseCreate::SetKeyFileOption);
     options.append(DatabaseCreate::SetPasswordOption);

--- a/src/cli/DatabaseInfo.cpp
+++ b/src/cli/DatabaseInfo.cpp
@@ -27,7 +27,7 @@
 
 DatabaseInfo::DatabaseInfo()
 {
-    name = QString("db-info");
+    name = QStringLiteral("db-info");
     description = QObject::tr("Show a database's information.");
 }
 

--- a/src/cli/Diceware.cpp
+++ b/src/cli/Diceware.cpp
@@ -37,7 +37,7 @@ const QCommandLineOption Diceware::WordListOption =
 
 Diceware::Diceware()
 {
-    name = QString("diceware");
+    name = QStringLiteral("diceware");
     description = QObject::tr("Generate a new random diceware passphrase.");
     options.append(Diceware::WordCountOption);
     options.append(Diceware::WordListOption);

--- a/src/cli/Edit.cpp
+++ b/src/cli/Edit.cpp
@@ -33,7 +33,7 @@ const QCommandLineOption Edit::TitleOption = QCommandLineOption(QStringList() <<
 
 Edit::Edit()
 {
-    name = QString("edit");
+    name = QStringLiteral("edit");
     description = QObject::tr("Edit an entry.");
     // Using some of the options from the Add command since they are the same.
     options.append(Add::UsernameOption);
@@ -41,7 +41,7 @@ Edit::Edit()
     options.append(Add::NotesOption);
     options.append(Add::PasswordPromptOption);
     options.append(Edit::TitleOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to edit."), QString("")});
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Path of the entry to edit."), QString()});
 
     // Password generation options.
     options.append(Add::GenerateOption);

--- a/src/cli/Estimate.cpp
+++ b/src/cli/Estimate.cpp
@@ -31,9 +31,9 @@ const QCommandLineOption Estimate::AdvancedOption =
 
 Estimate::Estimate()
 {
-    name = QString("estimate");
+    name = QStringLiteral("estimate");
     optionalArguments.append(
-        {QString("password"), QObject::tr("Password for which to estimate the entropy."), QString("[password]")});
+        {QStringLiteral("password"), QObject::tr("Password for which to estimate the entropy."), QStringLiteral("[password]")});
     options.append(Estimate::AdvancedOption);
     description = QObject::tr("Estimate the entropy of a password.");
 }

--- a/src/cli/Generate.cpp
+++ b/src/cli/Generate.cpp
@@ -67,7 +67,7 @@ const QCommandLineOption Generate::IncludeEveryGroupOption =
     QCommandLineOption(QStringList() << "every-group", QObject::tr("Include characters from every selected group"));
 Generate::Generate()
 {
-    name = QString("generate");
+    name = QStringLiteral("generate");
     description = QObject::tr("Generate a new random password.");
     options.append(Generate::PasswordLengthOption);
     options.append(Generate::LowerCaseOption);

--- a/src/cli/Help.cpp
+++ b/src/cli/Help.cpp
@@ -21,7 +21,7 @@
 
 Help::Help()
 {
-    name = QString("help");
+    name = QStringLiteral("help");
     description = QObject::tr("Display command help.");
 }
 

--- a/src/cli/Import.cpp
+++ b/src/cli/Import.cpp
@@ -38,10 +38,10 @@
 
 Import::Import()
 {
-    name = QString("import");
+    name = QStringLiteral("import");
     description = QObject::tr("Import the contents of an XML database.");
-    positionalArguments.append({QString("xml"), QObject::tr("Path of the XML database export."), QString("")});
-    positionalArguments.append({QString("database"), QObject::tr("Path of the new database."), QString("")});
+    positionalArguments.append({QStringLiteral("xml"), QObject::tr("Path of the XML database export."), QString()});
+    positionalArguments.append({QStringLiteral("database"), QObject::tr("Path of the new database."), QString()});
     options.append(DatabaseCreate::SetKeyFileOption);
     options.append(DatabaseCreate::SetKeyFileShortOption);
     options.append(DatabaseCreate::SetPasswordOption);

--- a/src/cli/List.cpp
+++ b/src/cli/List.cpp
@@ -34,12 +34,12 @@ const QCommandLineOption List::FlattenOption = QCommandLineOption(QStringList() 
 
 List::List()
 {
-    name = QString("ls");
+    name = QStringLiteral("ls");
     description = QObject::tr("List database entries.");
     options.append(List::RecursiveOption);
     options.append(List::FlattenOption);
     optionalArguments.append(
-        {QString("group"), QObject::tr("Path of the group to list. Default is /"), QString("[group]")});
+        {QStringLiteral("group"), QObject::tr("Path of the group to list. Default is /"), QStringLiteral("[group]")});
 }
 
 int List::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Merge.cpp
+++ b/src/cli/Merge.cpp
@@ -46,7 +46,7 @@ const QCommandLineOption Merge::YubiKeyFromOption(QStringList() << "yubikey-from
                                                   QObject::tr("slot"));
 Merge::Merge()
 {
-    name = QString("merge");
+    name = QStringLiteral("merge");
     description = QObject::tr("Merge two databases.");
     options.append(Merge::SameCredentialsOption);
     options.append(Merge::KeyFileFromOption);
@@ -55,7 +55,7 @@ Merge::Merge()
 #ifdef WITH_XC_YUBIKEY
     options.append(Merge::YubiKeyFromOption);
 #endif
-    positionalArguments.append({QString("database2"), QObject::tr("Path of the database to merge from."), QString("")});
+    positionalArguments.append({QStringLiteral("database2"), QObject::tr("Path of the database to merge from."), QString()});
 }
 
 int Merge::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Move.cpp
+++ b/src/cli/Move.cpp
@@ -25,10 +25,10 @@
 
 Move::Move()
 {
-    name = QString("mv");
+    name = QStringLiteral("mv");
     description = QObject::tr("Moves an entry to a new group.");
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to move."), QString("")});
-    positionalArguments.append({QString("group"), QObject::tr("Path of the destination group."), QString("")});
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Path of the entry to move."), QString()});
+    positionalArguments.append({QStringLiteral("group"), QObject::tr("Path of the destination group."), QString()});
 }
 
 Move::~Move() = default;

--- a/src/cli/Open.cpp
+++ b/src/cli/Open.cpp
@@ -21,7 +21,7 @@
 
 Open::Open()
 {
-    name = QString("open");
+    name = QStringLiteral("open");
     description = QObject::tr("Open a database.");
 }
 

--- a/src/cli/Remove.cpp
+++ b/src/cli/Remove.cpp
@@ -26,9 +26,9 @@
 
 Remove::Remove()
 {
-    name = QString("rm");
-    description = QString("Remove an entry from the database.");
-    positionalArguments.append({QString("entry"), QObject::tr("Path of the entry to remove."), QString("")});
+    name = QStringLiteral("rm");
+    description = QStringLiteral("Remove an entry from the database.");
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Path of the entry to remove."), QString()});
 }
 
 int Remove::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/RemoveGroup.cpp
+++ b/src/cli/RemoveGroup.cpp
@@ -26,9 +26,9 @@
 
 RemoveGroup::RemoveGroup()
 {
-    name = QString("rmdir");
-    description = QString("Removes a group from a database.");
-    positionalArguments.append({QString("group"), QObject::tr("Path of the group to remove."), QString("")});
+    name = QStringLiteral("rmdir");
+    description = QStringLiteral("Removes a group from a database.");
+    positionalArguments.append({QStringLiteral("group"), QObject::tr("Path of the group to remove."), QString()});
 }
 
 RemoveGroup::~RemoveGroup() = default;

--- a/src/cli/Search.cpp
+++ b/src/cli/Search.cpp
@@ -26,9 +26,9 @@
 
 Search::Search()
 {
-    name = QString("search");
+    name = QStringLiteral("search");
     description = QObject::tr("Find entries quickly.");
-    positionalArguments.append({QString("term"), QObject::tr("Search term."), QString("")});
+    positionalArguments.append({QStringLiteral("term"), QObject::tr("Search term."), QString()});
 }
 
 int Search::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Show.cpp
+++ b/src/cli/Show.cpp
@@ -49,14 +49,14 @@ const QCommandLineOption Show::AttributesOption = QCommandLineOption(
 
 Show::Show()
 {
-    name = QString("show");
+    name = QStringLiteral("show");
     description = QObject::tr("Show an entry's information.");
     options.append(Show::TotpOption);
     options.append(Show::AttributesOption);
     options.append(Show::ProtectedAttributesOption);
     options.append(Show::AllAttributesOption);
     options.append(Show::AttachmentsOption);
-    positionalArguments.append({QString("entry"), QObject::tr("Name of the entry to show."), QString("")});
+    positionalArguments.append({QStringLiteral("entry"), QObject::tr("Name of the entry to show."), QString()});
 }
 
 int Show::executeWithDatabase(QSharedPointer<Database> database, QSharedPointer<QCommandLineParser> parser)

--- a/src/cli/Utils.cpp
+++ b/src/cli/Utils.cpp
@@ -285,11 +285,11 @@ namespace Utils
 #endif
 
 #ifdef Q_OS_MACOS
-        clipPrograms << qMakePair(QStringLiteral("pbcopy"), QStringLiteral(""));
+        clipPrograms << qMakePair(QStringLiteral("pbcopy"), QString());
 #endif
 
 #ifdef Q_OS_WIN
-        clipPrograms << qMakePair(QStringLiteral("clip"), QStringLiteral(""));
+        clipPrograms << qMakePair(QStringLiteral("clip"), QString());
 #endif
 
         if (clipPrograms.isEmpty()) {

--- a/src/core/Config.cpp
+++ b/src/core/Config.cpp
@@ -61,7 +61,7 @@ static const QHash<Config::ConfigKey, ConfigDirective> configStrings = {
     {Config::AutoSaveOnExit,{QS("AutoSaveOnExit"), Roaming, true}},
     {Config::AutoSaveNonDataChanges,{QS("AutoSaveNonDataChanges"), Roaming, true}},
     {Config::BackupBeforeSave,{QS("BackupBeforeSave"), Roaming, false}},
-    {Config::BackupFilePathPattern,{QS("BackupFilePathPattern"), Roaming, QString("{DB_FILENAME}.old.kdbx")}},
+    {Config::BackupFilePathPattern,{QS("BackupFilePathPattern"), Roaming, QStringLiteral("{DB_FILENAME}.old.kdbx")}},
     {Config::UseAtomicSaves,{QS("UseAtomicSaves"), Roaming, true}},
     {Config::UseDirectWriteSaves,{QS("UseDirectWriteSaves"), Local, false}},
     {Config::SearchLimitGroup,{QS("SearchLimitGroup"), Roaming, false}},
@@ -485,7 +485,7 @@ void Config::init(const QString& configFileName, const QString& localConfigFileN
 #ifdef QT_DEBUG
         suffix = "_debug";
 #endif
-        oldLocalConfigPath += QString("/keepassxc%1.ini").arg(suffix);
+        oldLocalConfigPath += QStringLiteral("/keepassxc%1.ini").arg(suffix);
         oldLocalConfigPath = QDir::toNativeSeparators(oldLocalConfigPath);
         if (QFile::exists(oldLocalConfigPath)) {
             QDir().mkpath(QFileInfo(localConfigFileName).absolutePath());
@@ -553,8 +553,8 @@ QPair<QString, QString> Config::defaultConfigFiles()
     suffix = "_debug";
 #endif
 
-    configPath += QString("/keepassxc%1.ini").arg(suffix);
-    localConfigPath += QString("/keepassxc%1.ini").arg(suffix);
+    configPath += QStringLiteral("/keepassxc%1.ini").arg(suffix);
+    localConfigPath += QStringLiteral("/keepassxc%1.ini").arg(suffix);
 
     // Allow overriding the default location with env vars
     const auto& env = QProcessEnvironment::systemEnvironment();

--- a/src/core/Entry.cpp
+++ b/src/core/Entry.cpp
@@ -126,7 +126,7 @@ QString Entry::buildReference(const QUuid& uuid, const QString& field)
         return {};
     }
 
-    return QString("{REF:%1@I:%2}").arg(shortField, uuidStr);
+    return QStringLiteral("{REF:%1@I:%2}").arg(shortField, uuidStr);
 }
 
 EntryReferenceType Entry::referenceType(const QString& referenceStr)
@@ -388,7 +388,7 @@ QStringList Entry::getAllUrls() const
 
     for (const auto& key : m_attributes->keys()) {
         if (key.startsWith(EntryAttributes::AdditionalUrlAttribute)
-            || key == QString("%1_RELYING_PARTY").arg(EntryAttributes::PasskeyAttribute)) {
+            || key == QStringLiteral("%1_RELYING_PARTY").arg(EntryAttributes::PasskeyAttribute)) {
             auto additionalUrl = m_attributes->value(key);
             if (!additionalUrl.isEmpty()) {
                 urlList << resolveMultiplePlaceholders(additionalUrl);

--- a/src/core/EntryAttachments.cpp
+++ b/src/core/EntryAttachments.cpp
@@ -87,7 +87,7 @@ void EntryAttachments::set(const QString& key, const QByteArray& value)
 void EntryAttachments::remove(const QString& key)
 {
     if (!m_attachments.contains(key)) {
-        Q_ASSERT_X(false, "EntryAttachments::remove", qPrintable(QString("Can't find attachment for key %1").arg(key)));
+        Q_ASSERT_X(false, "EntryAttachments::remove", qPrintable(QStringLiteral("Can't find attachment for key %1").arg(key)));
         return;
     }
 
@@ -222,13 +222,13 @@ bool EntryAttachments::openAttachment(const QString& key, QString* errorMessage)
 
 #if defined(KEEPASSXC_DIST_SNAP)
         const QString tmpFileTemplate =
-            QString("%1/XXXXXXXXXXXX%2").arg(QProcessEnvironment::systemEnvironment().value("SNAP_USER_DATA"), ext);
+            QStringLiteral("%1/XXXXXXXXXXXX%2").arg(QProcessEnvironment::systemEnvironment().value("SNAP_USER_DATA"), ext);
 #elif defined(KEEPASSXC_DIST_FLATPAK)
         const QString tmpFileTemplate =
-            QString("%1/app/%2/XXXXXX.%3")
+            QStringLiteral("%1/app/%2/XXXXXX.%3")
                 .arg(QStandardPaths::writableLocation(QStandardPaths::RuntimeLocation), "org.keepassxc.KeePassXC", ext);
 #else
-        const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QString("XXXXXXXXXXXX").append(ext));
+        const QString tmpFileTemplate = QDir::temp().absoluteFilePath(QStringLiteral("XXXXXXXXXXXX").append(ext));
 #endif
 
         QTemporaryFile tmpFile(tmpFileTemplate);
@@ -237,7 +237,7 @@ bool EntryAttachments::openAttachment(const QString& key, QString* errorMessage)
                             && tmpFile.write(attachmentData) == attachmentData.size() && tmpFile.flush();
 
         if (!saveOk && errorMessage) {
-            *errorMessage = QString("%1 - %2").arg(key, tmpFile.errorString());
+            *errorMessage = QStringLiteral("%1 - %2").arg(key, tmpFile.errorString());
             return false;
         }
 

--- a/src/core/Group.cpp
+++ b/src/core/Group.cpp
@@ -717,7 +717,7 @@ Group* Group::findGroupByPath(const QString& groupPath)
     QString normalizedGroupPath;
 
     if (groupPath.isEmpty()) {
-        normalizedGroupPath = QString("/"); // root group
+        normalizedGroupPath = QStringLiteral("/"); // root group
     } else {
         // clang-format off
         normalizedGroupPath = (groupPath.startsWith("/") ? "" : "/")
@@ -761,7 +761,7 @@ QString Group::print(bool recursive, bool flatten, int depth)
             prefix += separator;
         }
     } else {
-        prefix = QString("  ").repeated(depth);
+        prefix = QStringLiteral("  ").repeated(depth);
     }
 
     if (entries().isEmpty() && children().isEmpty()) {
@@ -991,7 +991,7 @@ void Group::removeEntry(Entry* entry)
 {
     Q_ASSERT_X(m_entries.contains(entry),
                Q_FUNC_INFO,
-               QString("Group %1 does not contain %2").arg(this->name(), entry->title()).toLatin1());
+               QStringLiteral("Group %1 does not contain %2").arg(this->name(), entry->title()).toLatin1());
 
     emit entryAboutToRemove(entry);
 

--- a/src/core/HibpDownloader.cpp
+++ b/src/core/HibpDownloader.cpp
@@ -97,7 +97,7 @@ void HibpDownloader::validate()
         // The URL we query is https://api.pwnedpasswords.com/range/XXXXX,
         // where XXXXX is the first five bytes of the hex representation of
         // the password's SHA1.
-        const auto url = QString("https://api.pwnedpasswords.com/range/") + sha1Hex(password).left(5);
+        const auto url = QStringLiteral("https://api.pwnedpasswords.com/range/") + sha1Hex(password).left(5);
 
         // HIBP requires clients to specify a user agent in the request
         // (https://haveibeenpwned.com/API/v3#UserAgent); however, in order

--- a/src/core/Resources.cpp
+++ b/src/core/Resources.cpp
@@ -102,8 +102,8 @@ Resources::Resources()
 {
     const QString appDirPath = QCoreApplication::applicationDirPath();
 #if defined(Q_OS_UNIX) && !(defined(Q_OS_MACOS) && defined(WITH_APP_BUNDLE))
-    trySetResourceDir(KEEPASSX_DATA_DIR) || trySetResourceDir(QString("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))
-        || trySetResourceDir(QString("%1/%2").arg(KEEPASSX_PREFIX_DIR, KEEPASSX_DATA_DIR));
+    trySetResourceDir(KEEPASSX_DATA_DIR) || trySetResourceDir(QStringLiteral("%1/../%2").arg(appDirPath, KEEPASSX_DATA_DIR))
+        || trySetResourceDir(QStringLiteral("%1/%2").arg(KEEPASSX_PREFIX_DIR, KEEPASSX_DATA_DIR));
 #elif defined(Q_OS_MACOS) && defined(WITH_APP_BUNDLE)
     trySetResourceDir(appDirPath + QStringLiteral("/../Resources"));
 #elif defined(Q_OS_WIN)

--- a/src/core/Tools.cpp
+++ b/src/core/Tools.cpp
@@ -141,7 +141,7 @@ namespace Tools
             i++;
         }
 
-        return QString("%1 %2").arg(QLocale().toString(size, 'f', precision), units.at(i));
+        return QStringLiteral("%1 %2").arg(QLocale().toString(size, 'f', precision), units.at(i));
     }
 
     QString humanReadableTimeDifference(qint64 seconds)
@@ -461,13 +461,13 @@ namespace Tools
         QFileInfo dbFileInfo(databasePath);
         QString baseName = dbFileInfo.completeBaseName();
 
-        pattern.replace(QString("{DB_FILENAME}"), baseName);
+        pattern.replace(QStringLiteral("{DB_FILENAME}"), baseName);
 
         auto re = QRegularExpression(R"(\{TIME(?::([^\\]*))?\})");
         auto match = re.match(pattern);
         while (match.hasMatch()) {
             // Extract time format specifier
-            auto formatSpecifier = QString("dd_MM_yyyy_hh-mm-ss");
+            auto formatSpecifier = QStringLiteral("dd_MM_yyyy_hh-mm-ss");
             if (!match.captured(1).isEmpty()) {
                 formatSpecifier = match.captured(1);
             }

--- a/src/core/Totp.cpp
+++ b/src/core/Totp.cpp
@@ -36,10 +36,10 @@ static QList<Totp::Encoder> totpEncoders{
 
 static Totp::Algorithm getHashTypeByName(const QString& name)
 {
-    if (name.compare(QString("SHA512"), Qt::CaseInsensitive) == 0) {
+    if (name.compare(QStringLiteral("SHA512"), Qt::CaseInsensitive) == 0) {
         return Totp::Algorithm::Sha512;
     }
-    if (name.compare(QString("SHA256"), Qt::CaseInsensitive) == 0) {
+    if (name.compare(QStringLiteral("SHA256"), Qt::CaseInsensitive) == 0) {
         return Totp::Algorithm::Sha256;
     }
     return Totp::Algorithm::Sha1;
@@ -159,7 +159,7 @@ QString Totp::writeSettings(const QSharedPointer<Totp::Settings>& settings,
 
     // OTP Url output
     if (settings->format == StorageFormat::OTPURL || forceOtp) {
-        auto urlstring = QString("otpauth://totp/%1:%2?secret=%3&period=%4&digits=%5&issuer=%1")
+        auto urlstring = QStringLiteral("otpauth://totp/%1:%2?secret=%3&period=%4&digits=%5&issuer=%1")
                              .arg(title.isEmpty() ? "KeePassXC" : QString(QUrl::toPercentEncoding(title)),
                                   username.isEmpty() ? "none" : QString(QUrl::toPercentEncoding(username)),
                                   QString(QUrl::toPercentEncoding(Base32::sanitizeInput(settings->key.toLatin1()))),
@@ -175,7 +175,7 @@ QString Totp::writeSettings(const QSharedPointer<Totp::Settings>& settings,
         return urlstring;
     } else if (settings->format == StorageFormat::KEEOTP) {
         // KeeOtp output
-        auto keyString = QString("key=%1&size=%2&step=%3")
+        auto keyString = QStringLiteral("key=%1&size=%2&step=%3")
                              .arg(QString(Base32::sanitizeInput(settings->key.toLatin1())))
                              .arg(settings->digits)
                              .arg(settings->step);
@@ -185,10 +185,10 @@ QString Totp::writeSettings(const QSharedPointer<Totp::Settings>& settings,
         return keyString;
     } else if (!settings->encoder.shortName.isEmpty()) {
         // Semicolon output [step];[encoder]
-        return QString("%1;%2").arg(settings->step).arg(settings->encoder.shortName);
+        return QStringLiteral("%1;%2").arg(settings->step).arg(settings->encoder.shortName);
     } else {
         // Semicolon output [step];[digits]
-        return QString("%1;%2").arg(settings->step).arg(settings->digits);
+        return QStringLiteral("%1;%2").arg(settings->step).arg(settings->digits);
     }
 }
 

--- a/src/core/Translator.cpp
+++ b/src/core/Translator.cpp
@@ -123,7 +123,7 @@ QList<QPair<QString, QString>> Translator::availableLanguages()
                 languageStr = "Latin";
             }
             if (langcode.contains("_")) {
-                languageStr += QString(" (%1)").arg(QLocale::countryToString(locale.country()));
+                languageStr += QStringLiteral(" (%1)").arg(QLocale::countryToString(locale.country()));
             }
 
             QPair<QString, QString> language(langcode, languageStr);

--- a/src/core/UrlTools.cpp
+++ b/src/core/UrlTools.cpp
@@ -73,7 +73,7 @@ QString UrlTools::getBaseDomainFromUrl(const QString& url) const
     // Split the URL and select the last part, e.g. https://another.example -> example
     QString baseDomain = host.split('.').last();
     // Append the top level domain back to the URL, e.g. example -> example.co.uk
-    baseDomain.append(QString(".%1").arg(tld));
+    baseDomain.append(QStringLiteral(".%1").arg(tld));
 
     return baseDomain;
 }

--- a/src/crypto/Crypto.cpp
+++ b/src/crypto/Crypto.cpp
@@ -268,7 +268,7 @@ namespace Crypto
     QString debugInfo()
     {
         QString debugInfo = QObject::tr("Cryptographic libraries:").append("\n");
-        debugInfo.append(QString("- Botan %1.%2.%3\n")
+        debugInfo.append(QStringLiteral("- Botan %1.%2.%3\n")
                              .arg(Botan::version_major())
                              .arg(Botan::version_minor())
                              .arg(Botan::version_patch()));

--- a/src/fdosecrets/dbus/DBusMgr.cpp
+++ b/src/fdosecrets/dbus/DBusMgr.cpp
@@ -449,7 +449,7 @@ namespace FdoSecrets
         auto path = DBUS_PATH_TEMPLATE_COLLECTION.arg(DBUS_PATH_SECRETS, name);
         if (!registerObject(path, coll)) {
             // try again with a suffix
-            name.append(QString("_%1").arg(Tools::uuidToHex(QUuid::createUuid()).left(4)));
+            name.append(QStringLiteral("_%1").arg(Tools::uuidToHex(QUuid::createUuid()).left(4)));
             path = DBUS_PATH_TEMPLATE_COLLECTION.arg(DBUS_PATH_SECRETS, name);
 
             if (!registerObject(path, coll)) {

--- a/src/fdosecrets/objects/SessionCipher.h
+++ b/src/fdosecrets/objects/SessionCipher.h
@@ -65,7 +65,7 @@ namespace FdoSecrets
 
         QVariant negotiationOutput() const override
         {
-            return QStringLiteral("");
+            return QString();
         }
     };
 

--- a/src/format/BitwardenReader.cpp
+++ b/src/format/BitwardenReader.cpp
@@ -75,7 +75,7 @@ namespace
                 } else {
                     // Subsequent urls
                     entry->attributes()->set(
-                        QString("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), url);
+                        QStringLiteral("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), url);
                     ++i;
                 }
             }
@@ -143,7 +143,7 @@ namespace
             const auto fieldMap = field.toMap();
             auto name = fieldMap.value("name").toString();
             if (entry->attributes()->hasKey(name)) {
-                name = QString("%1_%2").arg(name, QUuid::createUuid().toString().mid(1, 5));
+                name = QStringLiteral("%1_%2").arg(name, QUuid::createUuid().toString().mid(1, 5));
             }
 
             const auto value = fieldMap.value("value").toString();

--- a/src/format/CsvExporter.cpp
+++ b/src/format/CsvExporter.cpp
@@ -70,7 +70,7 @@ QString CsvExporter::exportHeader()
     addColumn(header, "Icon");
     addColumn(header, "Last Modified");
     addColumn(header, "Created");
-    return header + QString("\n");
+    return header + QStringLiteral("\n");
 }
 
 QString CsvExporter::exportGroup(const Group* group, QString groupPath)

--- a/src/format/CsvParser.cpp
+++ b/src/format/CsvParser.cpp
@@ -256,7 +256,7 @@ void CsvParser::fillColumns()
         if (gap > 0) {
             CsvRow r = m_table.at(i);
             for (int j = 0; j < gap; ++j) {
-                r.append(QString(""));
+                r.append(QString());
             }
             m_table.replace(i, r);
         }

--- a/src/format/OPUXReader.cpp
+++ b/src/format/OPUXReader.cpp
@@ -76,7 +76,7 @@ namespace
                 const auto url = urlMap.value("url").toString();
                 if (entry->url() != url) {
                     entry->attributes()->set(
-                        QString("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), url);
+                        QStringLiteral("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), url);
                     ++i;
                 }
             }
@@ -121,13 +121,13 @@ namespace
                 if (name.isEmpty()) {
                     name = fieldMap.value("id").toString();
                 }
-                name = QString("%1_%2").arg(prefix, name);
+                name = QStringLiteral("%1_%2").arg(prefix, name);
 
                 const auto valueMap = fieldMap.value("value").toMap();
                 const auto key = valueMap.firstKey();
                 if (key == "totp") {
                     // Build otpauth url
-                    QUrl otpurl(QString("otpauth://totp/%1:%2?secret=%3")
+                    QUrl otpurl(QStringLiteral("otpauth://totp/%1:%2?secret=%3")
                                     .arg(entry->title(), entry->username(), valueMap.value(key).toString()));
 
                     if (entry->hasTotp()) {
@@ -136,7 +136,7 @@ namespace
                         name = "otp";
                         const auto attributes = entry->attributes()->keys();
                         while (attributes.contains(name)) {
-                            name = QString("otp_%1").arg(++i);
+                            name = QStringLiteral("otp_%1").arg(++i);
                         }
                         entry->attributes()->set(name, otpurl.toEncoded(), true);
                     } else {
@@ -148,7 +148,7 @@ namespace
                     const auto fileMap = valueMap.value(key).toMap();
                     const auto fileName = fileMap.value("fileName").toString();
                     const auto docId = fileMap.value("documentId").toString();
-                    const auto data = extractFile(uf, QString("files/%1__%2").arg(docId, fileName));
+                    const auto data = extractFile(uf, QStringLiteral("files/%1__%2").arg(docId, fileName));
                     if (!data.isNull()) {
                         entry->attachments()->set(fileName, data);
                     }
@@ -180,7 +180,7 @@ namespace
             const auto document = detailsMap.value("documentAttributes").toMap();
             const auto fileName = document.value("fileName").toString();
             const auto docId = document.value("documentId").toString();
-            const auto data = extractFile(uf, QString("files/%1__%2").arg(docId, fileName));
+            const auto data = extractFile(uf, QStringLiteral("files/%1__%2").arg(docId, fileName));
             if (!data.isNull()) {
                 entry->attachments()->set(fileName, data);
             }
@@ -227,7 +227,7 @@ namespace
         // Add the group icon if present
         const auto icon = attr.value("avatar").toString();
         if (!icon.isEmpty()) {
-            auto data = extractFile(uf, QString("files/%1").arg(icon));
+            auto data = extractFile(uf, QStringLiteral("files/%1").arg(icon));
             if (!data.isNull()) {
                 const auto uuid = QUuid::createUuid();
                 db->metadata()->addCustomIcon(uuid, data);

--- a/src/format/OpVaultReader.cpp
+++ b/src/format/OpVaultReader.cpp
@@ -99,7 +99,7 @@ QSharedPointer<Database> OpVaultReader::convert(QDir& opdataDir, const QString& 
             const QJsonObject bandEnt = bandJs[entryKey].toObject();
             const QString uuid = bandEnt["uuid"].toString();
             if (entryKey != uuid) {
-                qWarning() << QString("Mismatched Entry UUID, its JSON key <<%1>> and its UUID <<%2>>")
+                qWarning() << QStringLiteral("Mismatched Entry UUID, its JSON key <<%1>> and its UUID <<%2>>")
                                   .arg(entryKey)
                                   .arg(uuid);
             }
@@ -225,7 +225,7 @@ bool OpVaultReader::processFolderJson(QJsonObject& foldersJson, Group* rootGroup
         if (overviewJs.contains("smart") && overviewJs["smart"].toBool()) {
             if (!overviewJs.contains("predicate_b64")) {
                 const QString& errMsg =
-                    QString(R"(Expected a predicate in smart folder[uuid="%1"; title="%2"]))").arg(key, folderTitle);
+                    QStringLiteral(R"(Expected a predicate in smart folder[uuid="%1"; title="%2"]))").arg(key, folderTitle);
                 qWarning() << errMsg;
                 myGroup->setNotes(errMsg);
             } else {
@@ -270,16 +270,16 @@ QJsonObject OpVaultReader::readAndAssertJsonFile(QFile& file, const QString& str
     const QFileInfo& fileInfo = QFileInfo(file);
     auto absFilePath = fileInfo.absoluteFilePath();
     if (!fileInfo.exists()) {
-        qCritical() << QString("File \"%1\" must exist").arg(absFilePath);
+        qCritical() << QStringLiteral("File \"%1\" must exist").arg(absFilePath);
         return {};
     }
     if (!fileInfo.isReadable()) {
-        qCritical() << QString("File \"%1\" must be readable").arg(absFilePath);
+        qCritical() << QStringLiteral("File \"%1\" must be readable").arg(absFilePath);
         return {};
     }
 
     if (!file.open(QIODevice::ReadOnly | QIODevice::Text)) {
-        qCritical() << QString("Unable to open \"%1\" readonly+text").arg(absFilePath);
+        qCritical() << QStringLiteral("Unable to open \"%1\" readonly+text").arg(absFilePath);
     }
     filePayload = file.readAll();
     file.close();

--- a/src/format/OpVaultReaderAttachments.cpp
+++ b/src/format/OpVaultReaderAttachments.cpp
@@ -38,7 +38,7 @@ bool OpVaultReader::readAttachment(const QString& filePath,
 {
     QFile file(filePath);
     if (!file.open(QIODevice::ReadOnly)) {
-        qCritical() << QString("Unable to open \"%s\" for reading").arg(file.fileName());
+        qCritical() << QStringLiteral("Unable to open \"%s\" for reading").arg(file.fileName());
         return false;
     }
 
@@ -146,7 +146,7 @@ void OpVaultReader::fillAttachments(Entry* entry,
      * Attachment files are named with the UUID of the item that they are attached to followed by an underscore
      * and then followed by the UUID of the attachment itself. The file is then given the extension .attachment.
      */
-    auto fileFilter = QString("%1_*.attachment").arg(entry->uuidToHex().toUpper());
+    auto fileFilter = QStringLiteral("%1_*.attachment").arg(entry->uuidToHex().toUpper());
     const auto& attachInfoList = attachmentDir.entryInfoList(QStringList() << fileFilter, QDir::Files);
     int attachmentCount = attachInfoList.size();
     if (attachmentCount == 0) {
@@ -155,7 +155,7 @@ void OpVaultReader::fillAttachments(Entry* entry,
 
     for (const auto& info : attachInfoList) {
         if (!info.isReadable()) {
-            qCritical() << QString("Attachment file \"%1\" is not readable").arg(info.absoluteFilePath());
+            qCritical() << QStringLiteral("Attachment file \"%1\" is not readable").arg(info.absoluteFilePath());
             continue;
         }
         fillAttachment(entry, info, entryKey, entryHmacKey);
@@ -191,7 +191,7 @@ void OpVaultReader::fillAttachment(Entry* entry,
                 const QJsonValueRef& value = overObj[key];
                 QString insertAs = key;
                 for (int aa = 0; attachMetadata.contains(insertAs) && aa < 5; ++aa) {
-                    insertAs = QString("%1_%2").arg(key, aa);
+                    insertAs = QStringLiteral("%1_%2").arg(key, aa);
                 }
                 attachMetadata[insertAs] = value;
             }
@@ -200,22 +200,22 @@ void OpVaultReader::fillAttachment(Entry* entry,
         }
     } else {
         qCritical()
-            << QString("Unable to decode attach.overview for \"%1\": %2").arg(info.fileName(), over01.errorString());
+            << QStringLiteral("Unable to decode attach.overview for \"%1\": %2").arg(info.fileName(), over01.errorString());
     }
 
     QByteArray payload;
-    payload.append(QString("attachment file is actually %1 bytes\n").arg(info.size()).toUtf8());
+    payload.append(QStringLiteral("attachment file is actually %1 bytes\n").arg(info.size()).toUtf8());
     for (QString& key : attachMetadata.keys()) {
         const QJsonValueRef& value = attachMetadata[key];
         QByteArray valueBytes;
         if (value.isString()) {
             valueBytes = value.toString().toUtf8();
         } else if (value.isDouble()) {
-            valueBytes = QString("%1").arg(value.toInt()).toUtf8();
+            valueBytes = QStringLiteral("%1").arg(value.toInt()).toUtf8();
         } else if (value.isBool()) {
             valueBytes = value.toBool() ? "true" : "false";
         } else {
-            valueBytes = QString("Unexpected metadata type in attachment: %1").arg(value.type()).toUtf8();
+            valueBytes = QStringLiteral("Unexpected metadata type in attachment: %1").arg(value.type()).toUtf8();
         }
         payload.append(key.toUtf8()).append(":=").append(valueBytes).append("\n");
     }
@@ -226,12 +226,12 @@ void OpVaultReader::fillAttachment(Entry* entry,
         if (attFilename.isString()) {
             attachKey = attFilename.toString();
         } else {
-            qWarning() << QString("Unexpected type of attachment \"filename\": %1").arg(attFilename.type());
+            qWarning() << QStringLiteral("Unexpected type of attachment \"filename\": %1").arg(attFilename.type());
         }
     }
     if (entry->attachments()->hasKey(attachKey)) {
         // Prepend a random string to the attachment name to avoid collisions
-        attachKey.prepend(QString("%1_").arg(QUuid::createUuid().toString().mid(1, 5)));
+        attachKey.prepend(QStringLiteral("%1_").arg(QUuid::createUuid().toString().mid(1, 5)));
     }
 
     entry->attachments()->set(attachKey, attachPayload);

--- a/src/format/OpVaultReaderBandEntry.cpp
+++ b/src/format/OpVaultReaderBandEntry.cpp
@@ -69,7 +69,7 @@ bool OpVaultReader::decryptBandEntry(const QJsonObject& bandEntry,
     const QByteArray& realHmacSig =
         CryptoHash::hmac(kBA.mid(0, kBA.size() - hmacSig.size()), m_masterHmacKey, CryptoHash::Sha256);
     if (realHmacSig != hmacSig) {
-        qCritical() << QString(R"(Entry "k" failed its HMAC in UUID "%1", wanted "%2" got "%3")")
+        qCritical() << QStringLiteral(R"(Entry "k" failed its HMAC in UUID "%1", wanted "%2" got "%3")")
                            .arg(uuid)
                            .arg(QString::fromUtf8(hmacSig.toHex()))
                            .arg(QString::fromUtf8(realHmacSig));
@@ -107,7 +107,7 @@ Entry* OpVaultReader::processBandEntry(const QJsonObject& bandEntry, const QDir&
 {
     const QString uuid = bandEntry.value("uuid").toString();
     if (!(uuid.size() == 32 || uuid.size() == 36)) {
-        qWarning() << QString("Skipping suspicious band UUID <<%1>> with length %2").arg(uuid).arg(uuid.size());
+        qWarning() << QStringLiteral("Skipping suspicious band UUID <<%1>> with length %2").arg(uuid).arg(uuid.size());
         return nullptr;
     }
 
@@ -130,11 +130,11 @@ Entry* OpVaultReader::processBandEntry(const QJsonObject& bandEntry, const QDir&
                 }
             }
             if (!found) {
-                qWarning() << QString("Unable to place Entry.Category \"%1\" so using the Root instead").arg(category);
+                qWarning() << QStringLiteral("Unable to place Entry.Category \"%1\" so using the Root instead").arg(category);
                 entry->setGroup(rootGroup);
             }
         } else {
-            qWarning() << QString(R"(Skipping non-String Category type "%1" in UUID "%2")")
+            qWarning() << QStringLiteral(R"(Skipping non-String Category type "%1" in UUID "%2")")
                               .arg(categoryValue.type())
                               .arg(uuid);
             entry->setGroup(rootGroup);
@@ -244,7 +244,7 @@ bool OpVaultReader::fillAttributes(Entry* entry, const QJsonObject& bandEntry)
             if (newUrl != url) {
                 // Add this url if it isn't the base one
                 entry->attributes()->set(
-                    QString("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), newUrl);
+                    QStringLiteral("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i)), newUrl);
                 ++i;
             }
         }

--- a/src/format/OpVaultReaderSections.cpp
+++ b/src/format/OpVaultReaderSections.cpp
@@ -91,17 +91,17 @@ void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionNam
             QString name("otp");
             auto attributes = entry->attributes()->keys();
             while (attributes.contains(name)) {
-                name = QString("otp_%1").arg(++i);
+                name = QStringLiteral("otp_%1").arg(++i);
             }
             entry->attributes()->set(name, attrValue, true);
         } else if (attrValue.startsWith("otpauth://")) {
             QUrlQuery query(attrValue);
             // at least as of 1Password 7, they don't append the digits= and period= which totp.cpp requires
             if (!query.hasQueryItem("digits")) {
-                query.addQueryItem("digits", QString("%1").arg(Totp::DEFAULT_DIGITS));
+                query.addQueryItem("digits", QStringLiteral("%1").arg(Totp::DEFAULT_DIGITS));
             }
             if (!query.hasQueryItem("period")) {
-                query.addQueryItem("period", QString("%1").arg(Totp::DEFAULT_STEP));
+                query.addQueryItem("period", QStringLiteral("%1").arg(Totp::DEFAULT_STEP));
             }
             attrValue = query.toString(QUrl::FullyEncoded);
             entry->setTotp(Totp::parseSettings(attrValue));
@@ -115,7 +115,7 @@ void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionNam
             entry->setExpiryTime(expiry);
             entry->setExpires(true);
         } else {
-            qWarning() << QString("[%1] Invalid expiration date found: %2").arg(entry->title(), attrValue);
+            qWarning() << QStringLiteral("[%1] Invalid expiration date found: %2").arg(entry->title(), attrValue);
         }
     } else {
         if (kind == "date" || kind == "monthYear") {
@@ -124,18 +124,18 @@ void OpVaultReader::fillFromSectionField(Entry* entry, const QString& sectionNam
                 entry->attributes()->set(attrName, QLocale::system().toString(date, QLocale::ShortFormat));
             } else {
                 qWarning()
-                    << QString("[%1] Invalid date attribute found: %2 = %3").arg(entry->title(), attrName, attrValue);
+                    << QStringLiteral("[%1] Invalid date attribute found: %2 = %3").arg(entry->title(), attrName, attrValue);
             }
         } else if (kind == "address") {
             // Expand address into multiple attributes
             auto addrFields = field.value("v").toObject().toVariantMap();
             for (auto& part : addrFields.keys()) {
-                entry->attributes()->set(attrName + QString("_%1").arg(part), addrFields.value(part).toString());
+                entry->attributes()->set(attrName + QStringLiteral("_%1").arg(part), addrFields.value(part).toString());
             }
         } else {
             if (entry->attributes()->hasKey(attrName)) {
                 // Append a random string to the attribute name to avoid collisions
-                attrName += QString("_%1").arg(QUuid::createUuid().toString().mid(1, 5));
+                attrName += QStringLiteral("_%1").arg(QUuid::createUuid().toString().mid(1, 5));
             }
             entry->attributes()->set(attrName, attrValue, (kind == "password" || kind == "concealed"));
         }
@@ -165,5 +165,5 @@ QString OpVaultReader::resolveAttributeName(const QString& section, const QStrin
         return text;
     }
 
-    return QString("%1_%2").arg(section, text);
+    return QStringLiteral("%1_%2").arg(section, text);
 }

--- a/src/gui/DatabaseOpenWidget.cpp
+++ b/src/gui/DatabaseOpenWidget.cpp
@@ -465,7 +465,7 @@ void DatabaseOpenWidget::reject()
 
 bool DatabaseOpenWidget::browseKeyFile()
 {
-    QString filters = QString("%1 (*);;%2 (*.keyx; *.key)").arg(tr("All files"), tr("Key files"));
+    QString filters = QStringLiteral("%1 (*);;%2 (*.keyx; *.key)").arg(tr("All files"), tr("Key files"));
     QString filename =
         fileDialog()->getOpenFileName(this, tr("Select key file"), FileDialog::getLastDir("keyfile"), filters);
     if (filename.isEmpty()) {

--- a/src/gui/DatabaseTabWidget.cpp
+++ b/src/gui/DatabaseTabWidget.cpp
@@ -134,7 +134,7 @@ DatabaseWidget* DatabaseTabWidget::newDatabase()
 
 void DatabaseTabWidget::openDatabase()
 {
-    auto filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
+    auto filter = QStringLiteral("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
     auto fileName = fileDialog()->getOpenFileName(this, tr("Open database"), FileDialog::getLastDir("db"), filter);
     if (!fileName.isEmpty()) {
         FileDialog::saveLastDir("db", fileName, true);
@@ -303,7 +303,7 @@ void DatabaseTabWidget::mergeDatabase()
 {
     auto dbWidget = currentDatabaseWidget();
     if (dbWidget && !dbWidget->isLocked()) {
-        auto filter = QString("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
+        auto filter = QStringLiteral("%1 (*.kdbx);;%2 (*)").arg(tr("KeePass 2 Database"), tr("All files"));
         auto fileName =
             fileDialog()->getOpenFileName(this, tr("Merge database"), FileDialog::getLastDir("merge"), filter);
         if (!fileName.isEmpty()) {

--- a/src/gui/DatabaseWidget.cpp
+++ b/src/gui/DatabaseWidget.cpp
@@ -1182,7 +1182,7 @@ void DatabaseWidget::loadDatabase(bool accepted)
                 m_nextSearchLabelText =
                     tr("Entries expiring within %1 day(s)", "", expirationOffset).arg(expirationOffset);
             }
-            requestSearch(QString("is:expired-%1").arg(expirationOffset));
+            requestSearch(QStringLiteral("is:expired-%1").arg(expirationOffset));
         }
 
         m_groupBeforeLock = QUuid();

--- a/src/gui/EditWidgetIcons.cpp
+++ b/src/gui/EditWidgetIcons.cpp
@@ -250,7 +250,7 @@ void EditWidgetIcons::addCustomIconFromFile()
         return;
     }
 
-    auto filter = QString("%1 (%2);;%3 (*)").arg(tr("Images"), Icons::imageFormatsFilter(), tr("All files"));
+    auto filter = QStringLiteral("%1 (%2);;%3 (*)").arg(tr("Images"), Icons::imageFormatsFilter(), tr("All files"));
     auto filenames =
         fileDialog()->getOpenFileNames(this, tr("Select Image(s)"), FileDialog::getLastDir("icons"), filter);
     if (!filenames.empty()) {

--- a/src/gui/EntryPreviewWidget.cpp
+++ b/src/gui/EntryPreviewWidget.cpp
@@ -277,7 +277,7 @@ void EntryPreviewWidget::setUsernameVisible(bool state)
         m_ui->entryUsernameLabel->setFont(Font::defaultFont());
         m_ui->entryUsernameLabel->setCursorPosition(0);
     } else {
-        m_ui->entryUsernameLabel->setText(QString("\u25cf").repeated(6));
+        m_ui->entryUsernameLabel->setText(QStringLiteral("\u25cf").repeated(6));
         m_ui->entryUsernameLabel->setFont(Font::fixedFont());
     }
 
@@ -311,7 +311,7 @@ void EntryPreviewWidget::setPasswordVisible(bool state)
     } else if (password.isEmpty() && !config()->get(Config::Security_PasswordEmptyPlaceholder).toBool()) {
         m_ui->entryPasswordLabel->setText("");
     } else {
-        m_ui->entryPasswordLabel->setText(QString("\u25cf").repeated(6));
+        m_ui->entryPasswordLabel->setText(QStringLiteral("\u25cf").repeated(6));
     }
 
     m_ui->passwordScrollArea->setMaximumHeight(m_ui->entryPasswordLabel->sizeHint().height()
@@ -340,7 +340,7 @@ void EntryPreviewWidget::setNotesVisible(QTextEdit* notesWidget, const QString& 
         notesWidget->ensureCursorVisible();
     } else {
         if (!notes.isEmpty()) {
-            notesWidget->setPlainText(QString("\u25cf").repeated(6));
+            notesWidget->setPlainText(QStringLiteral("\u25cf").repeated(6));
         } else {
             notesWidget->setPlainText("");
         }
@@ -443,7 +443,7 @@ void EntryPreviewWidget::updateEntryAdvancedTab()
                     if (state) {
                         item->setText(item->data(Qt::UserRole).toString());
                     } else {
-                        item->setText(QString("\u25cf").repeated(6));
+                        item->setText(QStringLiteral("\u25cf").repeated(6));
                     }
                     // Maintain button height while showing contents of cell
                     auto size = btn->size();
@@ -452,7 +452,7 @@ void EntryPreviewWidget::updateEntryAdvancedTab()
                 });
 
                 m_ui->entryAttributesTable->setCellWidget(i, 1, button);
-                m_ui->entryAttributesTable->setItem(i, 2, new QTableWidgetItem(QString("\u25cf").repeated(6)));
+                m_ui->entryAttributesTable->setItem(i, 2, new QTableWidgetItem(QStringLiteral("\u25cf").repeated(6)));
             } else {
                 m_ui->entryAttributesTable->setItem(i, 2, new QTableWidgetItem(attributes->value(key)));
             }
@@ -586,8 +586,8 @@ void EntryPreviewWidget::setTabEnabled(QTabWidget* tabWidget, QWidget* widget, b
 QString EntryPreviewWidget::hierarchy(const Group* group, const QString& title)
 {
     if (group) {
-        QString groupList = QString("%1").arg(group->hierarchy().join(" / "));
-        return title.isEmpty() ? groupList : QString("%1 / %2").arg(groupList, title);
+        QString groupList = QStringLiteral("%1").arg(group->hierarchy().join(" / "));
+        return title.isEmpty() ? groupList : QStringLiteral("%1 / %2").arg(groupList, title);
     }
     return {};
 }

--- a/src/gui/HtmlExporter.cpp
+++ b/src/gui/HtmlExporter.cpp
@@ -36,7 +36,7 @@ namespace
         QByteArray a;
         QBuffer buffer(&a);
         pixmap.save(&buffer, "PNG");
-        return QString("<img src=\"data:image/png;base64,") + a.toBase64() + "\"/>";
+        return QStringLiteral("<img src=\"data:image/png;base64,") + a.toBase64() + "\"/>";
     }
 
     QString formatEntry(const Entry& entry)
@@ -138,7 +138,7 @@ bool HtmlExporter::exportDatabase(QIODevice* device,
         return false;
     }
 
-    const auto header = QString("<html>"
+    const auto header = QStringLiteral("<html>"
                                 "<head>"
                                 "<meta charset=\"UTF-8\">"
                                 "<title>"
@@ -173,7 +173,7 @@ bool HtmlExporter::exportDatabase(QIODevice* device,
                                 + "</p>"
                                   "<p><code>"
                                 + db->filePath().toHtmlEscaped() + "</code></p>");
-    const auto footer = QString("</body>"
+    const auto footer = QStringLiteral("</body>"
                                 "</html>");
 
     if (device->write(header.toUtf8()) == -1) {
@@ -213,7 +213,7 @@ bool HtmlExporter::writeGroup(QIODevice& device, const Group& group, QString pat
     const auto notes = group.notes();
     if (!group.entries().empty() || !notes.isEmpty()) {
         // Header line
-        auto header = QString("<hr><h2>");
+        auto header = QStringLiteral("<hr><h2>");
         header.append(PixmapToHTML(Icons::groupIconPixmap(&group, IconSize::Medium)));
         header.append("&nbsp;");
         header.append(path);
@@ -234,7 +234,7 @@ bool HtmlExporter::writeGroup(QIODevice& device, const Group& group, QString pat
     }
 
     // Begin the table for the entries in this group
-    auto table = QString("<table width=\"95%\">");
+    auto table = QStringLiteral("<table width=\"95%\">");
 
     auto entries = group.entries();
     if (sorted) {

--- a/src/gui/Icons.cpp
+++ b/src/gui/Icons.cpp
@@ -88,18 +88,18 @@ QIcon Icons::trayIcon(bool unlocked)
 
     auto iconApperance = trayIconAppearance();
     if (!iconApperance.startsWith("monochrome")) {
-        return icon(QString("%1%2").arg(applicationIconName(), suffix), false);
+        return icon(QStringLiteral("%1%2").arg(applicationIconName(), suffix), false);
     }
 
     QIcon i;
 #if defined(Q_OS_MACOS) || defined(Q_OS_WIN)
     if (osUtils->isStatusBarDark()) {
-        i = icon(QString("keepassxc-monochrome-light%1").arg(suffix), false);
+        i = icon(QStringLiteral("keepassxc-monochrome-light%1").arg(suffix), false);
     } else {
-        i = icon(QString("keepassxc-monochrome-dark%1").arg(suffix), false);
+        i = icon(QStringLiteral("keepassxc-monochrome-dark%1").arg(suffix), false);
     }
 #else
-    i = icon(QString("%1-%2%3").arg(applicationIconName(), iconApperance, suffix), false);
+    i = icon(QStringLiteral("%1-%2%3").arg(applicationIconName(), iconApperance, suffix), false);
 #endif
 #if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0)
     // Set as mask to allow the operating system to recolour the tray icon. This may look weird
@@ -181,7 +181,7 @@ QIcon Icons::icon(const QString& name, bool recolor, const QColor& overrideColor
 #endif
 
     QString cacheName =
-        QString("%1:%2:%3").arg(recolor ? "1" : "0", overrideColor.isValid() ? overrideColor.name() : "#", name);
+        QStringLiteral("%1:%2:%3").arg(recolor ? "1" : "0", overrideColor.isValid() ? overrideColor.name() : "#", name);
     QIcon icon = m_iconCache.value(cacheName);
 
     if (!icon.isNull() && !overrideColor.isValid()) {

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1136,7 +1136,7 @@ void MainWindow::updateWindowTitle()
     if (customWindowTitlePart.isEmpty()) {
         windowTitle = BaseWindowTitle;
     } else {
-        windowTitle = QString("%1[*] - %2").arg(customWindowTitlePart, BaseWindowTitle);
+        windowTitle = QStringLiteral("%1[*] - %2").arg(customWindowTitlePart, BaseWindowTitle);
     }
 
     if (customWindowTitlePart.isEmpty() || stackedWidgetIndex == 1) {
@@ -1228,12 +1228,12 @@ void MainWindow::openBugReportUrl()
 
 void MainWindow::openGettingStartedGuide()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_GettingStarted.html")));
+    customOpenUrl(QStringLiteral("file:///%1").arg(resources()->dataPath("docs/KeePassXC_GettingStarted.html")));
 }
 
 void MainWindow::openUserGuide()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_UserGuide.html")));
+    customOpenUrl(QStringLiteral("file:///%1").arg(resources()->dataPath("docs/KeePassXC_UserGuide.html")));
 }
 
 void MainWindow::openOnlineHelp()
@@ -1243,7 +1243,7 @@ void MainWindow::openOnlineHelp()
 
 void MainWindow::openKeyboardShortcuts()
 {
-    customOpenUrl(QString("file:///%1").arg(resources()->dataPath("docs/KeePassXC_KeyboardShortcuts.html")));
+    customOpenUrl(QStringLiteral("file:///%1").arg(resources()->dataPath("docs/KeePassXC_KeyboardShortcuts.html")));
 }
 
 void MainWindow::switchToDatabases()

--- a/src/gui/PasswordGeneratorWidget.cpp
+++ b/src/gui/PasswordGeneratorWidget.cpp
@@ -403,7 +403,7 @@ void PasswordGeneratorWidget::deleteWordList()
 
 void PasswordGeneratorWidget::addWordList()
 {
-    auto filter = QString("%1 (*.txt *.asc *.wordlist);;%2 (*)").arg(tr("Wordlists"), tr("All files"));
+    auto filter = QStringLiteral("%1 (*.txt *.asc *.wordlist);;%2 (*)").arg(tr("Wordlists"), tr("All files"));
     auto filePath = fileDialog()->getOpenFileName(this, tr("Select Custom Wordlist"), "", filter);
     if (filePath.isEmpty()) {
         return;

--- a/src/gui/csvImport/CsvImportWidget.cpp
+++ b/src/gui/csvImport/CsvImportWidget.cpp
@@ -155,12 +155,12 @@ void CsvImportWidget::updatePreview()
         if (m_ui->checkBoxFieldNames->isChecked()) {
             auto columnName = parser->getCsvTable().at(0).at(i);
             if (columnName.isEmpty()) {
-                csvColumns << QString(tr("Column %1").arg(i));
+                csvColumns << QStringLiteral(tr("Column %1").arg(i));
             } else {
                 csvColumns << columnName;
             }
         } else {
-            csvColumns << QString(tr("Column %1").arg(i));
+            csvColumns << QStringLiteral(tr("Column %1").arg(i));
         }
     }
     m_comboModel->setStringList(csvColumns);
@@ -299,7 +299,7 @@ QString CsvImportWidget::formatStatusText() const
         return text.section('\n', 0, 1).append("\n").append(tr("[%n more message(s) skipped]", "", items - 2));
     }
     if (items == 1) {
-        text.append(QString("\n"));
+        text.append(QStringLiteral("\n"));
     }
     return text;
 }

--- a/src/gui/csvImport/CsvParserModel.cpp
+++ b/src/gui/csvImport/CsvParserModel.cpp
@@ -44,7 +44,7 @@ void CsvParserModel::setFilename(const QString& filename)
 
 QString CsvParserModel::getFileInfo()
 {
-    return QString("%1, %2, %3")
+    return QStringLiteral("%1, %2, %3")
         .arg(Tools::humanReadableFileSize(m_parser->getFileSize()),
              tr("%n row(s)", "CSV row count", m_parser->getCsvRows()),
              tr("%n column(s)", "CSV column count", qMax(0, m_parser->getCsvCols() - 1)));

--- a/src/gui/databasekey/KeyFileEditWidget.cpp
+++ b/src/gui/databasekey/KeyFileEditWidget.cpp
@@ -106,7 +106,7 @@ void KeyFileEditWidget::createKeyFile()
     if (!m_compEditWidget) {
         return;
     }
-    QString filters = QString("%1 (*.keyx *.key);;%2 (*)").arg(tr("Key files"), tr("All files"));
+    QString filters = QStringLiteral("%1 (*.keyx *.key);;%2 (*)").arg(tr("Key files"), tr("All files"));
     QString fileName = fileDialog()->getSaveFileName(this, tr("Create Key File…"), QString(), filters);
 
     if (!fileName.isEmpty()) {
@@ -129,7 +129,7 @@ void KeyFileEditWidget::browseKeyFile()
     if (!m_compEditWidget) {
         return;
     }
-    QString filters = QString("%1 (*.keyx *.key);;%2 (*)").arg(tr("Key files"), tr("All files"));
+    QString filters = QStringLiteral("%1 (*.keyx *.key);;%2 (*)").arg(tr("Key files"), tr("All files"));
     QString fileName = fileDialog()->getOpenFileName(this, tr("Select a key file"), QString(), filters);
 
     if (QFileInfo(fileName).canonicalFilePath() == m_parent->getDatabase()->canonicalFilePath()) {

--- a/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetBrowser.cpp
@@ -124,7 +124,7 @@ void DatabaseSettingsWidgetBrowser::updateModel()
         if (key.startsWith(CustomData::BrowserKeyPrefix)) {
             QString strippedKey = key;
             strippedKey.remove(CustomData::BrowserKeyPrefix);
-            auto created = customData()->value(QString("%1_%2").arg(CustomData::Created, strippedKey));
+            auto created = customData()->value(QStringLiteral("%1_%2").arg(CustomData::Created, strippedKey));
             auto createdItem = new QStandardItem(created);
             createdItem->setEditable(false);
             m_customDataModel->appendRow(QList<QStandardItem*>()

--- a/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
+++ b/src/gui/dbsettings/DatabaseSettingsWidgetEncryption.cpp
@@ -268,7 +268,7 @@ bool DatabaseSettingsWidgetEncryption::save()
 
         QApplication::restoreOverrideCursor();
 
-        m_db->metadata()->customData()->set(CD_DECRYPTION_TIME_PREFERENCE_KEY, QString("%1").arg(time));
+        m_db->metadata()->customData()->set(CD_DECRYPTION_TIME_PREFERENCE_KEY, QStringLiteral("%1").arg(time));
 
         return ok;
     }

--- a/src/gui/entry/EditEntryWidget.cpp
+++ b/src/gui/entry/EditEntryWidget.cpp
@@ -334,7 +334,7 @@ void EditEntryWidget::insertURL()
     int i = 1;
 
     while (m_entryAttributes->keys().contains(name)) {
-        name = QString("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i));
+        name = QStringLiteral("%1_%2").arg(EntryAttributes::AdditionalUrlAttribute, QString::number(i));
         i++;
     }
 
@@ -876,12 +876,12 @@ void EditEntryWidget::loadEntry(Entry* entry,
     m_history = history;
 
     if (history) {
-        setHeadline(QString("%1 \u2022 %2").arg(parentName, tr("Entry history")));
+        setHeadline(QStringLiteral("%1 \u2022 %2").arg(parentName, tr("Entry history")));
     } else {
         if (create) {
-            setHeadline(QString("%1 \u2022 %2").arg(parentName, tr("Add entry")));
+            setHeadline(QStringLiteral("%1 \u2022 %2").arg(parentName, tr("Add entry")));
         } else {
-            setHeadline(QString("%1 \u2022 %2 \u2022 %3").arg(parentName, entry->title(), tr("Edit entry")));
+            setHeadline(QStringLiteral("%1 \u2022 %2 \u2022 %3").arg(parentName, entry->title(), tr("Edit entry")));
             // Reload entry details if changed outside of the edit dialog
             connect(m_entry, &Entry::modified, this, [this] { m_entryModifiedTimer.start(); });
         }
@@ -1663,7 +1663,7 @@ void EditEntryWidget::setupColorButton(bool foreground, const QColor& color)
     }
 
     if (color.isValid()) {
-        button->setStyleSheet(QString("background-color:%1").arg(color.name()));
+        button->setStyleSheet(QStringLiteral("background-color:%1").arg(color.name()));
         button->setProperty("color", color.name());
         checkBox->setChecked(true);
     } else {

--- a/src/gui/entry/EntryAttachmentsWidget.cpp
+++ b/src/gui/entry/EntryAttachmentsWidget.cpp
@@ -252,7 +252,7 @@ void EntryAttachmentsWidget::saveSelectedAttachments()
         const bool saveOk = file.open(QIODevice::WriteOnly) && file.setPermissions(QFile::ReadUser | QFile::WriteUser)
                             && file.write(attachmentData) == attachmentData.size();
         if (!saveOk) {
-            errors.append(QString("%1 - %2").arg(filename, file.errorString()));
+            errors.append(QStringLiteral("%1 - %2").arg(filename, file.errorString()));
         }
     }
 
@@ -286,7 +286,7 @@ void EntryAttachmentsWidget::openSelectedAttachments()
         QString errorMessage;
         if (!m_entryAttachments->openAttachment(m_attachmentsModel->keyByIndex(index), &errorMessage)) {
             const QString filename = m_attachmentsModel->keyByIndex(index);
-            errors.append(QString("%1 - %2").arg(filename, errorMessage));
+            errors.append(QStringLiteral("%1 - %2").arg(filename, errorMessage));
         };
     }
 
@@ -330,7 +330,7 @@ bool EntryAttachmentsWidget::insertAttachments(const QStringList& filenames, QSt
         if (readOk) {
             m_entryAttachments->set(fInfo.fileName(), data);
         } else {
-            errors.append(QString("%1 - %2").arg(fInfo.fileName(), file.errorString()));
+            errors.append(QStringLiteral("%1 - %2").arg(fInfo.fileName(), file.errorString()));
         }
     }
 

--- a/src/gui/entry/EntryModel.cpp
+++ b/src/gui/entry/EntryModel.cpp
@@ -37,7 +37,7 @@
 EntryModel::EntryModel(QObject* parent)
     : QAbstractTableModel(parent)
     , m_group(nullptr)
-    , HiddenContentDisplay(QString("\u25cf").repeated(6))
+    , HiddenContentDisplay(QStringLiteral("\u25cf").repeated(6))
 {
     connect(config(), &Config::changed, this, &EntryModel::onConfigChanged);
 }
@@ -210,7 +210,7 @@ QVariant EntryModel::data(const QModelIndex& index, int role) const
                     result.append(attachment);
                     continue;
                 }
-                result.append(QString(", ") + attachment);
+                result.append(QStringLiteral(", ") + attachment);
             }
             return result;
         }

--- a/src/gui/osutils/nixutils/NixUtils.cpp
+++ b/src/gui/osutils/nixutils/NixUtils.cpp
@@ -328,7 +328,7 @@ void NixUtils::setColorScheme(QDBusVariant value)
 
 quint64 NixUtils::getProcessStartTime() const
 {
-    QString processStatPath = QString("/proc/%1/stat").arg(QCoreApplication::applicationPid());
+    QString processStatPath = QStringLiteral("/proc/%1/stat").arg(QCoreApplication::applicationPid());
     QFile processStatFile(processStatPath);
 
     if (!processStatFile.open(QIODevice::ReadOnly | QIODevice::Text)) {

--- a/src/gui/osutils/nixutils/X11Funcs.cpp
+++ b/src/gui/osutils/nixutils/X11Funcs.cpp
@@ -32,7 +32,7 @@ KeySym qcharToNativeKeyCode(const QChar& ch)
     }
 
     /* request other characters from X server */
-    QString ustr = QString("U%1").arg(unicode, 4, 16, QLatin1Char('0'));
+    QString ustr = QStringLiteral("U%1").arg(unicode, 4, 16, QLatin1Char('0'));
     return XStringToKeysym(ustr.toStdString().c_str());
 }
 

--- a/src/gui/osutils/winutils/DeviceListenerWin.cpp
+++ b/src/gui/osutils/winutils/DeviceListenerWin.cpp
@@ -51,9 +51,9 @@ void DeviceListenerWin::registerHotplugCallback(bool arrived,
 
     QString regex = R"(^\\{2}\?\\[A-Z]+#)";
     if (vendorId > 0) {
-        regex += QString("VID_%1&").arg(vendorId, 0, 16).toUpper();
+        regex += QStringLiteral("VID_%1&").arg(vendorId, 0, 16).toUpper();
         if (productId > 0) {
-            regex += QString("PID_%1&").arg(productId, 0, 16).toUpper();
+            regex += QStringLiteral("PID_%1&").arg(productId, 0, 16).toUpper();
         }
     }
     m_deviceIdMatch = QRegularExpression(regex);

--- a/src/gui/osutils/winutils/WinUtils.cpp
+++ b/src/gui/osutils/winutils/WinUtils.cpp
@@ -125,7 +125,7 @@ void WinUtils::setLaunchAtStartup(bool enable)
 {
     QSettings reg(R"(HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run)", QSettings::NativeFormat);
     if (enable) {
-        reg.setValue(qAppName(), QString("\"%1\"").arg(QDir::toNativeSeparators(QApplication::applicationFilePath())));
+        reg.setValue(qAppName(), QStringLiteral("\"%1\"").arg(QDir::toNativeSeparators(QApplication::applicationFilePath())));
     } else {
         reg.remove(qAppName());
     }

--- a/src/gui/passkeys/PasskeyExporter.cpp
+++ b/src/gui/passkeys/PasskeyExporter.cpp
@@ -66,7 +66,7 @@ void PasskeyExporter::showExportDialog(const QList<Entry*>& items)
  */
 void PasskeyExporter::exportSelectedEntry(const Entry* entry, const QString& folder)
 {
-    const auto fullPath = QString("%1/%2.passkey").arg(folder, Tools::cleanFilename(entry->title()));
+    const auto fullPath = QStringLiteral("%1/%2.passkey").arg(folder, Tools::cleanFilename(entry->title()));
     if (QFile::exists(fullPath)) {
         auto dialogResult = MessageBox::warning(nullptr,
                                                 tr("KeePassXC: Passkey Export"),

--- a/src/gui/passkeys/PasskeyImporter.cpp
+++ b/src/gui/passkeys/PasskeyImporter.cpp
@@ -32,7 +32,7 @@ static const QString IMPORTED_PASSKEYS_GROUP = QStringLiteral("Imported Passkeys
 
 void PasskeyImporter::importPasskey(QSharedPointer<Database>& database, Entry* entry)
 {
-    auto filter = QString("%1 (*.passkey);;%2 (*)").arg(tr("Passkey file"), tr("All files"));
+    auto filter = QStringLiteral("%1 (*.passkey);;%2 (*)").arg(tr("Passkey file"), tr("All files"));
     auto fileName =
         fileDialog()->getOpenFileName(nullptr, tr("Open Passkey file"), FileDialog::getLastDir("passkey"), filter);
     if (fileName.isEmpty()) {

--- a/src/gui/styles/base/BaseStyle.cpp
+++ b/src/gui/styles/base/BaseStyle.cpp
@@ -3096,7 +3096,7 @@ QIcon BaseStyle::standardIcon(StandardPixmap sp, const QStyleOption* opt, const 
         return icons()->icon("chevron-double-right");
     case SP_LineEditClearButton:
         return icons()->icon(
-            QString("edit-clear-locationbar-").append((opt->direction == Qt::LeftToRight) ? "rtl" : "ltr"));
+            QStringLiteral("edit-clear-locationbar-").append((opt->direction == Qt::LeftToRight) ? "rtl" : "ltr"));
     default:
         return QCommonStyle::standardIcon(sp, opt, widget);
     }

--- a/src/gui/tag/TagModel.cpp
+++ b/src/gui/tag/TagModel.cpp
@@ -28,9 +28,9 @@
 TagModel::TagModel(QObject* parent)
     : QAbstractListModel(parent)
 {
-    m_defaultSearches << qMakePair(tr("Clear Search"), QString("")) << qMakePair(tr("All Entries"), QString("*"))
-                      << qMakePair(tr("Expired"), QString("is:expired"))
-                      << qMakePair(tr("Weak Passwords"), QString("is:weak"));
+    m_defaultSearches << qMakePair(tr("Clear Search"), QString()) << qMakePair(tr("All Entries"), QStringLiteral("*"))
+                      << qMakePair(tr("Expired"), QStringLiteral("is:expired"))
+                      << qMakePair(tr("Weak Passwords"), QStringLiteral("is:weak"));
 }
 
 TagModel::~TagModel() = default;
@@ -69,7 +69,7 @@ void TagModel::updateTagList()
     for (auto tag : m_db->tagList()) {
         auto escapedTag = tag;
         escapedTag.replace("\"", "\\\"");
-        m_tagList << qMakePair(tag, QString("tag:\"%1\"").arg(escapedTag));
+        m_tagList << qMakePair(tag, QStringLiteral("tag:\"%1\"").arg(escapedTag));
     }
 
     endResetModel();

--- a/src/gui/wizard/ImportWizardPageSelect.cpp
+++ b/src/gui/wizard/ImportWizardPageSelect.cpp
@@ -143,7 +143,7 @@ void ImportWizardPageSelect::updateDatabaseChoices() const
             // Add the root group as a special line item
             auto db = dbWidget->database();
             m_ui->existingDatabaseChoice->addItem(
-                QString("%1 (%2)").arg(dbWidget->displayName(), db->rootGroup()->name()),
+                QStringLiteral("%1 (%2)").arg(dbWidget->displayName(), db->rootGroup()->name()),
                 QList<QVariant>() << db->uuid() << db->rootGroup()->uuid());
 
             if (dbWidget->isVisible()) {
@@ -155,7 +155,7 @@ void ImportWizardPageSelect::updateDatabaseChoices() const
                 if (!group->isRecycled()) {
                     auto path = group->hierarchy();
                     path.removeFirst();
-                    m_ui->existingDatabaseChoice->addItem(QString("  / %1").arg(path.join(" / ")),
+                    m_ui->existingDatabaseChoice->addItem(QStringLiteral("  / %1").arg(path.join(" / ")),
                                                           QList<QVariant>() << db->uuid() << group->uuid());
                 }
             }
@@ -184,7 +184,7 @@ void ImportWizardPageSelect::chooseImportFile()
 
 void ImportWizardPageSelect::chooseKeyFile()
 {
-    auto filter = QString("%1 (*);;%2 (*.keyx; *.key)").arg(tr("All files"), tr("Key files"));
+    auto filter = QStringLiteral("%1 (*);;%2 (*.keyx; *.key)").arg(tr("All files"), tr("Key files"));
     auto file = fileDialog()->getOpenFileName(this, tr("Select key file"), QDir::homePath(), filter);
     if (!file.isEmpty()) {
         m_ui->keyFileEdit->setText(file);
@@ -221,15 +221,15 @@ QString ImportWizardPageSelect::importFileFilter()
 {
     switch (field("ImportType").toInt()) {
     case ImportWizard::IMPORT_CSV:
-        return QString("%1 (*.csv);;%2 (*)").arg(tr("Comma Separated Values"), tr("All files"));
+        return QStringLiteral("%1 (*.csv);;%2 (*)").arg(tr("Comma Separated Values"), tr("All files"));
     case ImportWizard::IMPORT_OPUX:
-        return QString("%1 (*.1pux)").arg(tr("1Password Export"));
+        return QStringLiteral("%1 (*.1pux)").arg(tr("1Password Export"));
     case ImportWizard::IMPORT_BITWARDEN:
-        return QString("%1 (*.json)").arg(tr("Bitwarden JSON Export"));
+        return QStringLiteral("%1 (*.json)").arg(tr("Bitwarden JSON Export"));
     case ImportWizard::IMPORT_OPVAULT:
-        return QString("%1 (*.opvault)").arg(tr("1Password Vault"));
+        return QStringLiteral("%1 (*.opvault)").arg(tr("1Password Vault"));
     case ImportWizard::IMPORT_KEEPASS1:
-        return QString("%1 (*.kdb)").arg(tr("KeePass1 Database"));
+        return QStringLiteral("%1 (*.kdb)").arg(tr("KeePass1 Database"));
     default:
         return {};
     }

--- a/src/keeshare/ShareExport.cpp
+++ b/src/keeshare/ShareExport.cpp
@@ -145,7 +145,7 @@ namespace
                 auto s = signer.signature(*randomGen()->getRng());
 
                 auto hex = QByteArray(reinterpret_cast<char*>(s.data()), s.size()).toHex();
-                signature = QString("rsa|%1").arg(QString::fromLatin1(hex));
+                signature = QStringLiteral("rsa|%1").arg(QString::fromLatin1(hex));
                 return true;
             } catch (std::exception& e) {
                 qWarning("KeeShare: Failed to sign data: %s", e.what());

--- a/src/keeshare/group/EditGroupWidgetKeeShare.cpp
+++ b/src/keeshare/group/EditGroupWidgetKeeShare.cpp
@@ -226,9 +226,9 @@ void EditGroupWidgetKeeShare::launchPathSelectionDialog()
     supportedExtensions << KeeShare::unsignedContainerFileType() << KeeShare::signedContainerFileType();
 
     QStringList knownFilters;
-    knownFilters << QString("%1 (*.%2)").arg(tr("KeeShare container"), KeeShare::unsignedContainerFileType());
-    knownFilters << QString("%1 (*.%2)").arg(tr("KeeShare signed container"), KeeShare::signedContainerFileType());
-    knownFilters << QString("%1 (*)").arg("All files");
+    knownFilters << QStringLiteral("%1 (*.%2)").arg(tr("KeeShare container"), KeeShare::unsignedContainerFileType());
+    knownFilters << QStringLiteral("%1 (*.%2)").arg(tr("KeeShare signed container"), KeeShare::signedContainerFileType());
+    knownFilters << QStringLiteral("%1 (*)").arg("All files");
 
     const auto filters = knownFilters.join(";;");
     auto defaultDirPath = FileDialog::getLastDir("keeshare");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -122,7 +122,7 @@ int main(int argc, char** argv)
         const wchar_t* absolutePathWchar = reinterpret_cast<const wchar_t*>(fileInfo.absoluteFilePath().utf16());
         hFind = FindFirstFileW(absolutePathWchar, &findFileData);
         if (hFind != INVALID_HANDLE_VALUE) {
-            fileNames << QString("%1/%2").arg(fileInfo.absolutePath(), QString::fromWCharArray(findFileData.cFileName));
+            fileNames << QStringLiteral("%1/%2").arg(fileInfo.absolutePath(), QString::fromWCharArray(findFileData.cFileName));
             FindClose(hFind);
         }
     }

--- a/src/sshagent/OpenSSHKey.cpp
+++ b/src/sshagent/OpenSSHKey.cpp
@@ -39,8 +39,8 @@ OpenSSHKey::OpenSSHKey(QObject* parent)
     : QObject(parent)
     , m_check(0)
     , m_type(QString())
-    , m_cipherName(QString("none"))
-    , m_kdfName(QString("none"))
+    , m_cipherName(QStringLiteral("none"))
+    , m_kdfName(QStringLiteral("none"))
     , m_kdfOptions(QByteArray())
     , m_rawType(QString())
     , m_rawData(QByteArray())
@@ -137,17 +137,17 @@ const QString OpenSSHKey::privateKey()
     BinaryStream stream(&sshKey);
 
     // magic
-    stream.write(QString("openssh-key-v1").toUtf8());
+    stream.write(QStringLiteral("openssh-key-v1").toUtf8());
     stream.write(static_cast<quint8>(0));
 
     // cipher name
-    stream.writeString(QString("none"));
+    stream.writeString(QStringLiteral("none"));
 
     // kdf name
-    stream.writeString(QString("none"));
+    stream.writeString(QStringLiteral("none"));
 
     // kdf options
-    stream.writeString(QString(""));
+    stream.writeString(QString());
 
     // number of keys
     stream.write(static_cast<quint32>(1));

--- a/src/sshagent/OpenSSHKeyGen.cpp
+++ b/src/sshagent/OpenSSHKeyGen.cpp
@@ -84,10 +84,10 @@ namespace OpenSSHKeyGen
     bool generateECDSA(OpenSSHKey& key, int bits)
     {
         auto rng = randomGen()->getRng();
-        QString group = QString("nistp%1").arg(bits);
+        QString group = QStringLiteral("nistp%1").arg(bits);
 
         try {
-            Botan::EC_Group domain(QString("secp%1r1").arg(bits).toStdString());
+            Botan::EC_Group domain(QStringLiteral("secp%1r1").arg(bits).toStdString());
             Botan::ECDSA_PrivateKey ecdsaKey(*rng, domain);
 
             QByteArray publicData;

--- a/src/sshagent/OpenSSHKeyGenDialog.cpp
+++ b/src/sshagent/OpenSSHKeyGenDialog.cpp
@@ -55,14 +55,14 @@ void OpenSSHKeyGenDialog::typeChanged()
 {
     m_ui->bitsComboBox->clear();
 
-    if (m_ui->typeComboBox->currentText() == QString("Ed25519")) {
+    if (m_ui->typeComboBox->currentText() == QStringLiteral("Ed25519")) {
         m_ui->bitsComboBox->addItem("32");
-    } else if (m_ui->typeComboBox->currentText() == QString("RSA")) {
+    } else if (m_ui->typeComboBox->currentText() == QStringLiteral("RSA")) {
         m_ui->bitsComboBox->addItem("2048");
         m_ui->bitsComboBox->addItem("3072");
         m_ui->bitsComboBox->addItem("4096");
         m_ui->bitsComboBox->setCurrentText("3072");
-    } else if (m_ui->typeComboBox->currentText() == QString("ECDSA")) {
+    } else if (m_ui->typeComboBox->currentText() == QStringLiteral("ECDSA")) {
         m_ui->bitsComboBox->addItem("256");
         m_ui->bitsComboBox->addItem("384");
         m_ui->bitsComboBox->addItem("521");
@@ -78,11 +78,11 @@ void OpenSSHKeyGenDialog::accept()
 
     int bits = m_ui->bitsComboBox->currentText().toInt();
 
-    if (m_ui->typeComboBox->currentText() == QString("Ed25519")) {
+    if (m_ui->typeComboBox->currentText() == QStringLiteral("Ed25519")) {
         OpenSSHKeyGen::generateEd25519(*m_key);
-    } else if (m_ui->typeComboBox->currentText() == QString("RSA")) {
+    } else if (m_ui->typeComboBox->currentText() == QStringLiteral("RSA")) {
         OpenSSHKeyGen::generateRSA(*m_key, bits);
-    } else if (m_ui->typeComboBox->currentText() == QString("ECDSA")) {
+    } else if (m_ui->typeComboBox->currentText() == QStringLiteral("ECDSA")) {
         OpenSSHKeyGen::generateECDSA(*m_key, bits);
     } else {
         reject();

--- a/src/sshagent/SSHAgent.cpp
+++ b/src/sshagent/SSHAgent.cpp
@@ -211,7 +211,7 @@ bool SSHAgent::sendMessagePageant(const QByteArray& in, QByteArray& out)
     }
 
     auto threadId = reinterpret_cast<qlonglong>(QThread::currentThreadId());
-    QByteArray mapName = (QString("SSHAgentRequest%1").arg(threadId, 8, 16, QChar('0'))).toLatin1();
+    QByteArray mapName = (QStringLiteral("SSHAgentRequest%1").arg(threadId, 8, 16, QChar('0'))).toLatin1();
 
     HANDLE handle = CreateFileMappingA(INVALID_HANDLE_VALUE, NULL, PAGE_READWRITE, 0, AGENT_MAX_MSGLEN, mapName.data());
 
@@ -301,7 +301,7 @@ bool SSHAgent::addIdentity(OpenSSHKey& key, const KeeAgentSettings& settings, co
 
     if (isSecurityKey) {
         request.write(SSH_AGENT_CONSTRAIN_EXTENSION);
-        request.writeString(QString("sk-provider@openssh.com"));
+        request.writeString(QStringLiteral("sk-provider@openssh.com"));
         request.writeString(securityKeyProvider());
     }
 

--- a/src/updatecheck/UpdateChecker.cpp
+++ b/src/updatecheck/UpdateChecker.cpp
@@ -55,7 +55,7 @@ void UpdateChecker::checkForUpdates(bool manuallyRequested)
     if (m_isManuallyRequested || Clock::currentSecondsSinceEpoch() >= nextCheck) {
         m_bytesReceived.clear();
 
-        QString apiUrlStr = QString("https://api.github.com/repos/keepassxreboot/keepassxc/releases");
+        QString apiUrlStr = QStringLiteral("https://api.github.com/repos/keepassxreboot/keepassxc/releases");
 
         if (!config()->get(Config::GUI_CheckForUpdatesIncludeBetas).toBool()) {
             apiUrlStr += "/latest";
@@ -99,7 +99,7 @@ void UpdateChecker::fetchFinished()
 
         if (!jsonObject.value("tag_name").isUndefined()) {
             version = jsonObject.value("tag_name").toString();
-            hasNewVersion = compareVersions(QString(KEEPASSXC_VERSION), version);
+            hasNewVersion = compareVersions(QStringLiteral(KEEPASSXC_VERSION), version);
         }
 
         // Check again in 7 days

--- a/tests/TestAutoType.cpp
+++ b/tests/TestAutoType.cpp
@@ -134,7 +134,7 @@ void TestAutoType::testInternal()
     QVERIFY(m_platform->activeWindowTitle().isEmpty());
 
     m_test->setActiveWindowTitle("Test");
-    QCOMPARE(m_platform->activeWindowTitle(), QString("Test"));
+    QCOMPARE(m_platform->activeWindowTitle(), QStringLiteral("Test"));
 }
 
 void TestAutoType::testSingleAutoType()
@@ -143,7 +143,7 @@ void TestAutoType::testSingleAutoType()
 
     QCOMPARE(m_test->actionCount(), 14);
     QCOMPARE(m_test->actionChars(),
-             QString("myuser%1mypass%2").arg(m_test->keyToString(Qt::Key_Tab)).arg(m_test->keyToString(Qt::Key_Enter)));
+             QStringLiteral("myuser%1mypass%2").arg(m_test->keyToString(Qt::Key_Tab)).arg(m_test->keyToString(Qt::Key_Enter)));
 }
 
 void TestAutoType::testGlobalAutoTypeWithNoMatch()
@@ -161,7 +161,7 @@ void TestAutoType::testGlobalAutoTypeWithOneMatch()
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
 
-    QCOMPARE(m_test->actionChars(), QString("%1association%2").arg(m_entry1->username()).arg(m_entry1->password()));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("%1association%2").arg(m_entry1->username()).arg(m_entry1->password()));
 }
 
 void TestAutoType::testGlobalAutoTypeTitleMatch()
@@ -172,7 +172,7 @@ void TestAutoType::testGlobalAutoTypeTitleMatch()
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
 
-    QCOMPARE(m_test->actionChars(), QString("%1%2").arg(m_entry2->password(), m_test->keyToString(Qt::Key_Enter)));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("%1%2").arg(m_entry2->password(), m_test->keyToString(Qt::Key_Enter)));
 }
 
 void TestAutoType::testGlobalAutoTypeUrlMatch()
@@ -183,7 +183,7 @@ void TestAutoType::testGlobalAutoTypeUrlMatch()
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
 
-    QCOMPARE(m_test->actionChars(), QString("%1%2").arg(m_entry5->password(), m_test->keyToString(Qt::Key_Enter)));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("%1%2").arg(m_entry5->password(), m_test->keyToString(Qt::Key_Enter)));
 }
 
 void TestAutoType::testGlobalAutoTypeUrlSubdomainMatch()
@@ -194,7 +194,7 @@ void TestAutoType::testGlobalAutoTypeUrlSubdomainMatch()
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
 
-    QCOMPARE(m_test->actionChars(), QString("%1%2").arg(m_entry5->password(), m_test->keyToString(Qt::Key_Enter)));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("%1%2").arg(m_entry5->password(), m_test->keyToString(Qt::Key_Enter)));
 }
 
 void TestAutoType::testGlobalAutoTypeTitleMatchDisabled()
@@ -213,68 +213,68 @@ void TestAutoType::testGlobalAutoTypeRegExp()
     m_test->setActiveWindowTitle("lorem REGEX1 ipsum");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("regex1"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("regex1"));
     m_test->clearActions();
 
     // should be case-insensitive
     m_test->setActiveWindowTitle("lorem regex1 ipsum");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("regex1"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("regex1"));
     m_test->clearActions();
 
     // exact match
     m_test->setActiveWindowTitle("REGEX2");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("regex2"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("regex2"));
     m_test->clearActions();
 
     // a bit more complicated regex
     m_test->setActiveWindowTitle("REGEX3-R2D2");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("regex3"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("regex3"));
     m_test->clearActions();
 
     // with custom attributes
     m_test->setActiveWindowTitle("CustomAttr1");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("custom_attr:Attribute"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("custom_attr:Attribute"));
     m_test->clearActions();
 
     // with (non uppercase) undefined custom attributes
     m_test->setActiveWindowTitle("CustomAttr2");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString(""));
+    QCOMPARE(m_test->actionChars(), QString());
     m_test->clearActions();
 
     // with mixedcase default attributes
     m_test->setActiveWindowTitle("CustomAttr3");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("custom_attr"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("custom_attr"));
     m_test->clearActions();
 
     // with resolve placeholders in window association title
     m_test->setActiveWindowTitle("AttrValueFirst");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("custom_attr_first"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("custom_attr_first"));
     m_test->clearActions();
 
     m_test->setActiveWindowTitle("lorem AttrValueFirstAndAttrValueSecond ipsum");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("custom_attr_first_and_second"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("custom_attr_first_and_second"));
     m_test->clearActions();
 
     m_test->setActiveWindowTitle("lorem AttrValueThird ipsum");
     emit osUtils->globalShortcutTriggered("autotype");
     m_autoType->performGlobalAutoType(m_dbList);
-    QCOMPARE(m_test->actionChars(), QString("custom_attr_third"));
+    QCOMPARE(m_test->actionChars(), QStringLiteral("custom_attr_third"));
     m_test->clearActions();
 }
 
@@ -300,19 +300,19 @@ void TestAutoType::testAutoTypeResults_data()
     QTest::addColumn<QString>("expectedResult");
 
     // Normal Sequences
-    QTest::newRow("Sequence with Attributes") << QString("{USERNAME} {PASSWORD} {URL} {S:attr1}")
-                                              << QString("Username Password@1 https://example.com value1");
-    QTest::newRow("Sequence with Comment") << QString("{USERNAME}{TAB}{C:Extra Tab}{TAB}{S:attr1}")
-                                           << QString("Username[Key0x1000001][Key0x1000001]value1");
+    QTest::newRow("Sequence with Attributes") << QStringLiteral("{USERNAME} {PASSWORD} {URL} {S:attr1}")
+                                              << QStringLiteral("Username Password@1 https://example.com value1");
+    QTest::newRow("Sequence with Comment") << QStringLiteral("{USERNAME}{TAB}{C:Extra Tab}{TAB}{S:attr1}")
+                                           << QStringLiteral("Username[Key0x1000001][Key0x1000001]value1");
 
     // Conversions and Replacements
-    QTest::newRow("T-CONV UPPER") << QString("{T-CONV:/{USERNAME}/UPPER/}") << QString("USERNAME");
-    QTest::newRow("T-CONV LOWER") << QString("{T-CONV:/{USERNAME}/LOWER/}") << QString("username");
-    QTest::newRow("T-CONV BASE64") << QString("{T-CONV:/{USERNAME}/BASE64/}") << QString("VXNlcm5hbWU=");
-    QTest::newRow("T-CONV HEX") << QString("{T-CONV:/{USERNAME}/HEX/}") << QString("557365726e616d65");
-    QTest::newRow("T-CONV URI ENCODE") << QString("{T-CONV:/{URL}/URI/}") << QString("https%3A%2F%2Fexample.com");
-    QTest::newRow("T-CONV URI DECODE") << QString("{T-CONV:/{S:attr2}/URI-DEC/}") << QString("decode me");
-    QTest::newRow("T-REPLACE-RX") << QString("{T-REPLACE-RX:/{USERNAME}/(User)/$1Pass/}") << QString("UserPassname");
+    QTest::newRow("T-CONV UPPER") << QStringLiteral("{T-CONV:/{USERNAME}/UPPER/}") << QStringLiteral("USERNAME");
+    QTest::newRow("T-CONV LOWER") << QStringLiteral("{T-CONV:/{USERNAME}/LOWER/}") << QStringLiteral("username");
+    QTest::newRow("T-CONV BASE64") << QStringLiteral("{T-CONV:/{USERNAME}/BASE64/}") << QStringLiteral("VXNlcm5hbWU=");
+    QTest::newRow("T-CONV HEX") << QStringLiteral("{T-CONV:/{USERNAME}/HEX/}") << QStringLiteral("557365726e616d65");
+    QTest::newRow("T-CONV URI ENCODE") << QStringLiteral("{T-CONV:/{URL}/URI/}") << QStringLiteral("https%3A%2F%2Fexample.com");
+    QTest::newRow("T-CONV URI DECODE") << QStringLiteral("{T-CONV:/{S:attr2}/URI-DEC/}") << QStringLiteral("decode me");
+    QTest::newRow("T-REPLACE-RX") << QStringLiteral("{T-REPLACE-RX:/{USERNAME}/(User)/$1Pass/}") << QStringLiteral("UserPassname");
 }
 
 void TestAutoType::testAutoTypeSyntaxChecks()

--- a/tests/TestBase32.cpp
+++ b/tests/TestBase32.cpp
@@ -308,24 +308,24 @@ void TestBase32::testSanitizeInput()
     QByteArray encodedData = "JBSW Y3DP EB3W 64TM MQXC 4LQA";
     auto data = Base32::decode(Base32::sanitizeInput(encodedData));
     QVERIFY(!data.isEmpty());
-    QCOMPARE(QString(data.toStdString().c_str()), QString("Hello world..."));
+    QCOMPARE(QString(data.toStdString().c_str()), QStringLiteral("Hello world..."));
 
     // sanitize input (typo + missing padding)
     encodedData = "J8SWY3DPE83W64TMMQXC4LQA";
     data = Base32::decode(Base32::sanitizeInput(encodedData));
     QVERIFY(!data.isEmpty());
-    QCOMPARE(QString(data.toStdString().c_str()), QString("Hello world..."));
+    QCOMPARE(QString(data.toStdString().c_str()), QStringLiteral("Hello world..."));
 
     // sanitize input (other illegal characters)
     encodedData = "J8SWY3D[PE83W64TMMQ]XC!4LQA";
     data = Base32::decode(Base32::sanitizeInput(encodedData));
     QVERIFY(!data.isEmpty());
-    QCOMPARE(QString(data.toStdString().c_str()), QString("Hello world..."));
+    QCOMPARE(QString(data.toStdString().c_str()), QStringLiteral("Hello world..."));
 
     // sanitize input (NUL character)
     encodedData = "J8SWY3DPE83W64TMMQXC4LQA";
     encodedData.insert(3, '\0');
     data = Base32::decode(Base32::sanitizeInput(encodedData));
     QVERIFY(!data.isEmpty());
-    QCOMPARE(QString(data.toStdString().c_str()), QString("Hello world..."));
+    QCOMPARE(QString(data.toStdString().c_str()), QStringLiteral("Hello world..."));
 }

--- a/tests/TestBrowser.cpp
+++ b/tests/TestBrowser.cpp
@@ -64,7 +64,7 @@ void TestBrowser::testChangePublicKeys()
     json["nonce"] = NONCE;
 
     auto response = m_browserAction->processClientMessage(nullptr, json);
-    QCOMPARE(response["action"].toString(), QString("change-public-keys"));
+    QCOMPARE(response["action"].toString(), QStringLiteral("change-public-keys"));
     QCOMPARE(response["publicKey"].toString() == PUBLICKEY, false);
     QCOMPARE(response["success"].toString(), TRUE_STR);
 }
@@ -79,7 +79,7 @@ void TestBrowser::testEncryptMessage()
     m_browserAction->m_clientPublicKey = PUBLICKEY;
     auto encrypted = browserMessageBuilder()->encryptMessage(message, NONCE, PUBLICKEY, SERVERSECRETKEY);
 
-    QCOMPARE(encrypted, QString("+zjtntnk4rGWSl/Ph7Vqip/swvgeupk4lNgHEm2OO3ujNr0OMz6eQtGwjtsj+/rP"));
+    QCOMPARE(encrypted, QStringLiteral("+zjtntnk4rGWSl/Ph7Vqip/swvgeupk4lNgHEm2OO3ujNr0OMz6eQtGwjtsj+/rP"));
 }
 
 void TestBrowser::testDecryptMessage()
@@ -90,7 +90,7 @@ void TestBrowser::testDecryptMessage()
     m_browserAction->m_clientPublicKey = PUBLICKEY;
     auto decrypted = browserMessageBuilder()->decryptMessage(message, NONCE, PUBLICKEY, SERVERSECRETKEY);
 
-    QCOMPARE(decrypted["action"].toString(), QString("test-action"));
+    QCOMPARE(decrypted["action"].toString(), QStringLiteral("test-action"));
 }
 
 void TestBrowser::testGetBase64FromKey()
@@ -102,7 +102,7 @@ void TestBrowser::testGetBase64FromKey()
     }
 
     auto response = browserMessageBuilder()->getBase64FromKey(pk, crypto_box_PUBLICKEYBYTES);
-    QCOMPARE(response, QString("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="));
+    QCOMPARE(response, QStringLiteral("AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8="));
 }
 
 void TestBrowser::testIncrementNonce()
@@ -115,13 +115,13 @@ void TestBrowser::testBuildResponse()
 {
     const auto object = QJsonObject{{"test", true}};
     const QJsonArray arr = {QJsonObject{{"test", true}}};
-    const auto val = QString("value1");
+    const auto val = QStringLiteral("value1");
 
     // Note: Passing a const QJsonObject will fail
     const Parameters params{
         {"test-param-1", val}, {"test-param-2", 2}, {"test-param-3", false}, {"object", object}, {"arr", arr}};
 
-    const auto action = QString("test-action");
+    const auto action = QStringLiteral("test-action");
     const auto message = browserMessageBuilder()->buildResponse(action, NONCE, params, PUBLICKEY, SERVERSECRETKEY);
     QVERIFY(!message.isEmpty());
     QCOMPARE(message["action"].toString(), action);
@@ -130,7 +130,7 @@ void TestBrowser::testBuildResponse()
     const auto decrypted =
         browserMessageBuilder()->decryptMessage(message["message"].toString(), NONCE, PUBLICKEY, SERVERSECRETKEY);
     QVERIFY(!decrypted.isEmpty());
-    QCOMPARE(decrypted["test-param-1"].toString(), QString("value1"));
+    QCOMPARE(decrypted["test-param-1"].toString(), QStringLiteral("value1"));
     QCOMPARE(decrypted["test-param-2"].toInt(), 2);
     QCOMPARE(decrypted["test-param-3"].toBool(), false);
 
@@ -219,21 +219,21 @@ void TestBrowser::testSearchEntries()
         m_browserService->searchEntries(db, "https://github.com", "https://github.com/session"); // db, url, submitUrl
 
     QCOMPARE(result.length(), 9);
-    QCOMPARE(result[0]->url(), QString("https://github.com/login_page"));
-    QCOMPARE(result[1]->url(), QString("https://github.com/login"));
-    QCOMPARE(result[2]->url(), QString("https://github.com/"));
-    QCOMPARE(result[3]->url(), QString("github.com/login"));
-    QCOMPARE(result[4]->url(), QString("http://github.com"));
-    QCOMPARE(result[5]->url(), QString("http://github.com/login"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com/login_page"));
+    QCOMPARE(result[1]->url(), QStringLiteral("https://github.com/login"));
+    QCOMPARE(result[2]->url(), QStringLiteral("https://github.com/"));
+    QCOMPARE(result[3]->url(), QStringLiteral("github.com/login"));
+    QCOMPARE(result[4]->url(), QStringLiteral("http://github.com"));
+    QCOMPARE(result[5]->url(), QStringLiteral("http://github.com/login"));
 
     // With matching there should be only 3 results + 4 without a scheme
     browserSettings()->setMatchUrlScheme(true);
     result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     QCOMPARE(result.length(), 7);
-    QCOMPARE(result[0]->url(), QString("https://github.com/login_page"));
-    QCOMPARE(result[1]->url(), QString("https://github.com/login"));
-    QCOMPARE(result[2]->url(), QString("https://github.com/"));
-    QCOMPARE(result[3]->url(), QString("github.com/login"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com/login_page"));
+    QCOMPARE(result[1]->url(), QStringLiteral("https://github.com/login"));
+    QCOMPARE(result[2]->url(), QStringLiteral("https://github.com/"));
+    QCOMPARE(result[3]->url(), QStringLiteral("github.com/login"));
 }
 
 void TestBrowser::testSearchEntriesByPath()
@@ -339,8 +339,8 @@ void TestBrowser::testSearchEntriesByReference()
 
     auto firstEntryUuid = entries.first()->uuidToHex();
     auto secondEntryUuid = entries[1]->uuidToHex();
-    auto fullReference = QString("{REF:A@I:%1}").arg(firstEntryUuid);
-    auto partialReference = QString("https://subdomain.{REF:A@I:%1}").arg(secondEntryUuid);
+    auto fullReference = QStringLiteral("{REF:A@I:%1}").arg(firstEntryUuid);
+    auto partialReference = QStringLiteral("https://subdomain.{REF:A@I:%1}").arg(secondEntryUuid);
     entries[2]->attributes()->set(EntryAttributes::AdditionalUrlAttribute, fullReference);
     entries[3]->attributes()->set(EntryAttributes::AdditionalUrlAttribute, partialReference);
     entries[4]->setUrl(fullReference);
@@ -375,7 +375,7 @@ void TestBrowser::testSearchEntriesWithPort()
 
     auto result = m_browserService->searchEntries(db, "http://127.0.0.1:443", "http://127.0.0.1");
     QCOMPARE(result.length(), 1);
-    QCOMPARE(result[0]->url(), QString("http://127.0.0.1:443"));
+    QCOMPARE(result[0]->url(), QStringLiteral("http://127.0.0.1:443"));
 }
 
 void TestBrowser::testSearchEntriesWithAdditionalURLs()
@@ -392,12 +392,12 @@ void TestBrowser::testSearchEntriesWithAdditionalURLs()
 
     auto result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     QCOMPARE(result.length(), 1);
-    QCOMPARE(result[0]->url(), QString("https://github.com/"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com/"));
 
     // Search the additional URL. It should return the same entry
     auto additionalResult = m_browserService->searchEntries(db, "https://keepassxc.org", "https://keepassxc.org");
     QCOMPARE(additionalResult.length(), 1);
-    QCOMPARE(additionalResult[0]->url(), QString("https://github.com/"));
+    QCOMPARE(additionalResult[0]->url(), QStringLiteral("https://github.com/"));
 }
 
 void TestBrowser::testInvalidEntries()
@@ -422,8 +422,8 @@ void TestBrowser::testInvalidEntries()
     browserSettings()->setMatchUrlScheme(true);
     auto result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     QCOMPARE(result.length(), 2);
-    QCOMPARE(result[0]->url(), QString("https://github.com/login"));
-    QCOMPARE(result[1]->url(), QString("//github.com"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com/login"));
+    QCOMPARE(result[1]->url(), QStringLiteral("//github.com"));
 
     // Test the URL's directly
     QCOMPARE(m_browserService->handleURL(urls[0], url, submitUrl), true);
@@ -456,31 +456,31 @@ void TestBrowser::testSubdomainsAndPaths()
     browserSettings()->setMatchUrlScheme(false);
     auto result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     QCOMPARE(result.length(), 1);
-    QCOMPARE(result[0]->url(), QString("https://github.com"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com"));
 
     // With www subdomain
     result = m_browserService->searchEntries(db, "https://www.github.com", "https://www.github.com/session");
     QCOMPARE(result.length(), 4);
-    QCOMPARE(result[0]->url(), QString("https://www.github.com/login/page.xml"));
-    QCOMPARE(result[1]->url(), QString("https://github.com")); // Accepts any subdomain
-    QCOMPARE(result[2]->url(), QString("http://www.github.com"));
-    QCOMPARE(result[3]->url(), QString("www.github.com/"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://www.github.com/login/page.xml"));
+    QCOMPARE(result[1]->url(), QStringLiteral("https://github.com")); // Accepts any subdomain
+    QCOMPARE(result[2]->url(), QStringLiteral("http://www.github.com"));
+    QCOMPARE(result[3]->url(), QStringLiteral("www.github.com/"));
 
     // With www subdomain omitted
     root->setCustomDataTriState(BrowserService::OPTION_OMIT_WWW, Group::Enable);
     result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     root->setCustomDataTriState(BrowserService::OPTION_OMIT_WWW, Group::Inherit);
     QCOMPARE(result.length(), 4);
-    QCOMPARE(result[0]->url(), QString("https://www.github.com/login/page.xml"));
-    QCOMPARE(result[1]->url(), QString("https://github.com"));
-    QCOMPARE(result[2]->url(), QString("http://www.github.com"));
-    QCOMPARE(result[3]->url(), QString("www.github.com/"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://www.github.com/login/page.xml"));
+    QCOMPARE(result[1]->url(), QStringLiteral("https://github.com"));
+    QCOMPARE(result[2]->url(), QStringLiteral("http://www.github.com"));
+    QCOMPARE(result[3]->url(), QStringLiteral("www.github.com/"));
 
     // With scheme matching there should be only 1 result
     browserSettings()->setMatchUrlScheme(true);
     result = m_browserService->searchEntries(db, "https://github.com", "https://github.com/session");
     QCOMPARE(result.length(), 1);
-    QCOMPARE(result[0]->url(), QString("https://github.com"));
+    QCOMPARE(result[0]->url(), QStringLiteral("https://github.com"));
 
     // Test site with subdomain in the site URL
     QStringList entryURLs = {
@@ -497,18 +497,18 @@ void TestBrowser::testSubdomainsAndPaths()
 
     result = m_browserService->searchEntries(db, "https://accounts.example.com/", "https://accounts.example.com/");
     QCOMPARE(result.length(), 3);
-    QCOMPARE(result[0]->url(), QString("https://accounts.example.com"));
-    QCOMPARE(result[1]->url(), QString("https://accounts.example.com/path"));
-    QCOMPARE(result[2]->url(), QString("https://example.com/")); // Accepts any subdomain
+    QCOMPARE(result[0]->url(), QStringLiteral("https://accounts.example.com"));
+    QCOMPARE(result[1]->url(), QStringLiteral("https://accounts.example.com/path"));
+    QCOMPARE(result[2]->url(), QStringLiteral("https://example.com/")); // Accepts any subdomain
 
     result = m_browserService->searchEntries(
         db, "https://another.accounts.example.com/", "https://another.accounts.example.com/");
     QCOMPARE(result.length(), 4);
     QCOMPARE(result[0]->url(),
-             QString("https://accounts.example.com")); // Accepts any subdomain under accounts.example.com
-    QCOMPARE(result[1]->url(), QString("https://accounts.example.com/path"));
-    QCOMPARE(result[2]->url(), QString("https://another.accounts.example.com/"));
-    QCOMPARE(result[3]->url(), QString("https://example.com/")); // Accepts one or more subdomains
+             QStringLiteral("https://accounts.example.com")); // Accepts any subdomain under accounts.example.com
+    QCOMPARE(result[1]->url(), QStringLiteral("https://accounts.example.com/path"));
+    QCOMPARE(result[2]->url(), QStringLiteral("https://another.accounts.example.com/"));
+    QCOMPARE(result[3]->url(), QStringLiteral("https://example.com/")); // Accepts one or more subdomains
 
     // Test local files. It should be a direct match.
     QStringList localFiles = {"file:///Users/testUser/tests/test.html"};
@@ -528,9 +528,9 @@ QList<Entry*> TestBrowser::createEntries(QStringList& urls, Group* root) const
         entry->setGroup(root);
         entry->beginUpdate();
         entry->setUrl(urls[i]);
-        entry->setUsername(QString("User %1").arg(i));
+        entry->setUsername(QStringLiteral("User %1").arg(i));
         entry->setUuid(QUuid::createUuid());
-        entry->setTitle(QString("Name_%1").arg(entry->uuidToHex()));
+        entry->setTitle(QStringLiteral("Name_%1").arg(entry->uuidToHex()));
         entry->endUpdate();
         entries.push_back(entry);
     }
@@ -603,15 +603,15 @@ void TestBrowser::testBestMatchingCredentials()
     result = m_browserService->searchEntries(db, siteUrl, siteUrl);
     sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
     QCOMPARE(sorted.size(), 1);
-    QCOMPARE(sorted[0]->url(), QString("https://sub.github.com/justsomepage"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://sub.github.com/justsomepage"));
 
     // The matching should not care if there's a / path or not.
     siteUrl = "https://subdomain.example.com/";
     result = m_browserService->searchEntries(db, siteUrl, siteUrl);
     sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
     QCOMPARE(sorted.size(), 2);
-    QCOMPARE(sorted[0]->url(), QString("https://subdomain.example.com"));
-    QCOMPARE(sorted[1]->url(), QString("https://subdomain.example.com/"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://subdomain.example.com"));
+    QCOMPARE(sorted[1]->url(), QStringLiteral("https://subdomain.example.com/"));
 
     // Entries with https://example.com should be still returned even if the site URL has a subdomain. Those have the
     // best match.
@@ -624,8 +624,8 @@ void TestBrowser::testBestMatchingCredentials()
     sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
 
     QCOMPARE(sorted.size(), 2);
-    QCOMPARE(sorted[0]->url(), QString("https://example.com"));
-    QCOMPARE(sorted[1]->url(), QString("https://example.com"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://example.com"));
+    QCOMPARE(sorted[1]->url(), QStringLiteral("https://example.com"));
 
     // https://github.com/keepassxreboot/keepassxc/issues/4754
     db = QSharedPointer<Database>::create();
@@ -716,27 +716,27 @@ void TestBrowser::testRestrictBrowserKey()
     auto entries3 = createEntries(urls3, group3);
 
     // Browser 'key0': Groups 1 and 2 are excluded, so entries 0 and 3 will be found
-    auto siteUrl = QString("https://example.com");
+    auto siteUrl = QStringLiteral("https://example.com");
     auto result = m_browserService->searchEntries(db, siteUrl, siteUrl, {"key0"});
     auto sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
     QCOMPARE(sorted.size(), 2);
-    QCOMPARE(sorted[0]->url(), QString("https://example.com/3"));
-    QCOMPARE(sorted[1]->url(), QString("https://example.com/0"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://example.com/3"));
+    QCOMPARE(sorted[1]->url(), QStringLiteral("https://example.com/0"));
 
     // Browser 'key1': Group 2 will be excluded, so entries 0, 1, and 3 will be found
     result = m_browserService->searchEntries(db, siteUrl, siteUrl, {"key1"});
     sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
     QCOMPARE(sorted.size(), 3);
-    QCOMPARE(sorted[0]->url(), QString("https://example.com/3"));
-    QCOMPARE(sorted[1]->url(), QString("https://example.com/1"));
-    QCOMPARE(sorted[2]->url(), QString("https://example.com/0"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://example.com/3"));
+    QCOMPARE(sorted[1]->url(), QStringLiteral("https://example.com/1"));
+    QCOMPARE(sorted[2]->url(), QStringLiteral("https://example.com/0"));
 
     // Browser 'key2': Group 1 will be excluded, so entries 0, 2, 2b, 3 will be found
     result = m_browserService->searchEntries(db, siteUrl, siteUrl, {"key2"});
     sorted = m_browserService->sortEntries(result, siteUrl, siteUrl);
     QCOMPARE(sorted.size(), 4);
-    QCOMPARE(sorted[0]->url(), QString("https://example.com/3"));
-    QCOMPARE(sorted[1]->url(), QString("https://example.com/2b"));
-    QCOMPARE(sorted[2]->url(), QString("https://example.com/2"));
-    QCOMPARE(sorted[3]->url(), QString("https://example.com/0"));
+    QCOMPARE(sorted[0]->url(), QStringLiteral("https://example.com/3"));
+    QCOMPARE(sorted[1]->url(), QStringLiteral("https://example.com/2b"));
+    QCOMPARE(sorted[2]->url(), QStringLiteral("https://example.com/2"));
+    QCOMPARE(sorted[3]->url(), QStringLiteral("https://example.com/0"));
 }

--- a/tests/TestCli.cpp
+++ b/tests/TestCli.cpp
@@ -80,7 +80,7 @@ void TestCli::initTestCase()
 
 void TestCli::init()
 {
-    const auto file = QString(KEEPASSX_TEST_DATA_DIR).append("/%1");
+    const auto file = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/%1");
 
     m_dbFile.reset(new TemporaryFile());
     m_dbFile->copyFromFile(file.arg("NewDatabase.kdbx"));
@@ -309,10 +309,10 @@ void TestCli::testAdd()
     auto db = readDatabase();
     auto* entry = db->rootGroup()->findEntryByPath("/newuser-entry");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser"));
-    QCOMPARE(entry->url(), QString("https://example.com/"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser"));
+    QCOMPARE(entry->url(), QStringLiteral("https://example.com/"));
     QCOMPARE(entry->password().size(), 20);
-    QCOMPARE(entry->notes(), QString("some notes"));
+    QCOMPARE(entry->notes(), QStringLiteral("some notes"));
 
     // Quiet option
     setInput("a");
@@ -332,9 +332,9 @@ void TestCli::testAdd()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newuser-entry2");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser2"));
-    QCOMPARE(entry->url(), QString("https://example.net/"));
-    QCOMPARE(entry->password(), QString("newpassword"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser2"));
+    QCOMPARE(entry->url(), QStringLiteral("https://example.net/"));
+    QCOMPARE(entry->password(), QStringLiteral("newpassword"));
 
     // Password generation options
     setInput("a");
@@ -344,7 +344,7 @@ void TestCli::testAdd()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newuser-entry3");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser3"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser3"));
     QCOMPARE(entry->password().size(), 34);
     QRegularExpression defaultPasswordClassesRegex("^[a-zA-Z0-9]+$");
     QVERIFY(defaultPasswordClassesRegex.match(entry->password()).hasMatch());
@@ -369,7 +369,7 @@ void TestCli::testAdd()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newuser-entry4");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser4"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser4"));
     QCOMPARE(entry->password().size(), 20);
     QVERIFY(!defaultPasswordClassesRegex.match(entry->password()).hasMatch());
 
@@ -382,8 +382,8 @@ void TestCli::testAdd()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newuser-entry5");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser5"));
-    QCOMPARE(entry->notes(), QString("test\nnew line"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser5"));
+    QCOMPARE(entry->notes(), QStringLiteral("test\nnew line"));
 }
 
 void TestCli::testAddGroup()
@@ -401,7 +401,7 @@ void TestCli::testAddGroup()
     auto db = readDatabase();
     auto* group = db->rootGroup()->findGroupByPath("new_group");
     QVERIFY(group);
-    QCOMPARE(group->name(), QString("new_group"));
+    QCOMPARE(group->name(), QStringLiteral("new_group"));
 
     // Trying to add the same group should fail.
     setInput("a");
@@ -417,7 +417,7 @@ void TestCli::testAddGroup()
     db = readDatabase();
     group = db->rootGroup()->findGroupByPath("new_group/newer_group");
     QVERIFY(group);
-    QCOMPARE(group->name(), QString("newer_group"));
+    QCOMPARE(group->name(), QStringLiteral("newer_group"));
 
     // Should fail if the path is invalid.
     setInput("a");
@@ -438,7 +438,7 @@ void TestCli::testAnalyze()
     QVERIFY(!analyzeCmd.name.isEmpty());
     QVERIFY(analyzeCmd.getDescriptionLine().contains(analyzeCmd.name));
 
-    const QString hibpPath = QString(KEEPASSX_TEST_DATA_DIR).append("/hibp.txt");
+    const QString hibpPath = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/hibp.txt");
 
     setInput("a");
     execCmd(analyzeCmd, {"analyze", "--hibp", hibpPath, m_dbFile->fileName()});
@@ -491,7 +491,7 @@ void TestCli::testAttachmentExport()
     m_stderr->readLine(); // skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(),
-             QByteArray(qPrintable(QString("Successfully exported attachment %1 of entry %2 to %3.\n")
+             QByteArray(qPrintable(QStringLiteral("Successfully exported attachment %1 of entry %2 to %3.\n")
                                        .arg("Sample attachment.txt", "/Sample Entry", exportOutput.fileName()))));
 
     exportOutput.open(QIODeviceBase::ReadOnly);
@@ -521,7 +521,7 @@ void TestCli::testAttachmentImport()
     QVERIFY(!attachmentImportCmd.name.isEmpty());
     QVERIFY(attachmentImportCmd.getDescriptionLine().contains(attachmentImportCmd.name));
 
-    const QString attachmentPath = QString(KEEPASSX_TEST_DATA_DIR).append("/Attachment.txt");
+    const QString attachmentPath = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Attachment.txt");
     QVERIFY(QFile::exists(attachmentPath));
 
     // Try importing an attachment to a non-existent entry
@@ -570,7 +570,7 @@ void TestCli::testAttachmentImport()
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(),
              QByteArray(qPrintable(
-                 QString("Successfully imported attachment %1 as Sample attachment.txt to entry /Sample Entry.\n")
+                 QStringLiteral("Successfully imported attachment %1 as Sample attachment.txt to entry /Sample Entry.\n")
                      .arg(attachmentPath))));
 
     // Try importing an attachment with an unoccupied name
@@ -581,7 +581,7 @@ void TestCli::testAttachmentImport()
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(
         m_stdout->readAll(),
-        QByteArray(qPrintable(QString("Successfully imported attachment %1 as Attachment.txt to entry /Sample Entry.\n")
+        QByteArray(qPrintable(QStringLiteral("Successfully imported attachment %1 as Attachment.txt to entry /Sample Entry.\n")
                                   .arg(attachmentPath))));
 }
 
@@ -653,7 +653,7 @@ void TestCli::testClip()
 
     m_stderr->readLine(); // Skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
-    QTRY_COMPARE(clipboard->text(), QString("Password"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("Password"));
     QCOMPARE(m_stdout->readLine(), QByteArray("Entry's \"Password\" attribute copied to the clipboard!\n"));
 
     // Quiet option
@@ -661,17 +661,17 @@ void TestCli::testClip()
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0", "-q"});
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(), QByteArray());
-    QTRY_COMPARE(clipboard->text(), QString("Password"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("Password"));
 
     // Username
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0", "-a", "username"});
-    QTRY_COMPARE(clipboard->text(), QString("User Name"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("User Name"));
 
     // Uuid (top-level field)
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile->fileName(), "/Sample Entry", "0", "-a", "Uuid"});
-    QTRY_COMPARE(clipboard->text(), QString("{9f4544c2-ab00-c74a-8a1a-6eaf26cf57e9}"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("{9f4544c2-ab00-c74a-8a1a-6eaf26cf57e9}"));
 
     // TOTP
     setInput("a");
@@ -682,7 +682,7 @@ void TestCli::testClip()
     // Test Unicode
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFile2->fileName(), "/General/Unicode", "0", "-a", "username"});
-    QTRY_COMPARE(clipboard->text(), QString(R"(¯\_(ツ)_/¯)"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral(R"(¯\_(ツ)_/¯)"));
 
     // Password with timeout
     setInput("a");
@@ -692,8 +692,8 @@ void TestCli::testClip()
                                     QStringList{"clip", m_dbFile->fileName(), "/Sample Entry", "1"});
     // clang-format on
 
-    QTRY_COMPARE(clipboard->text(), QString("Password"));
-    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 3000);
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("Password"));
+    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(), 3000);
 
     future.waitForFinished();
 
@@ -704,7 +704,7 @@ void TestCli::testClip()
                                QStringList{"clip", m_dbFile->fileName(), "/Sample Entry", "1", "-t"});
 
     QTRY_VERIFY(isTotp(clipboard->text()));
-    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(""), 3000);
+    QTRY_COMPARE_WITH_TIMEOUT(clipboard->text(), QString(), 3000);
 
     future.waitForFinished();
 
@@ -733,7 +733,7 @@ void TestCli::testClip()
 
     setInput("a");
     execCmd(clipCmd, {"clip", m_dbFileMulti->fileName(), "Entry 2", "0", "-b"});
-    QTRY_COMPARE(clipboard->text(), QString("Password2"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("Password2"));
 }
 
 void TestCli::testCreate()
@@ -790,7 +790,7 @@ void TestCli::testCreate()
     execCmd(createCmd, {"db-create", dbFilename, "-p"});
     // Output should be empty when there is an error.
     QCOMPARE(m_stdout->readAll(), QByteArray());
-    QString errorMessage = QString("File " + dbFilename + " already exists.\n");
+    QString errorMessage = QStringLiteral("File " + dbFilename + " already exists.\n");
     QCOMPARE(m_stderr->readAll(), errorMessage.toUtf8());
 
     // Should refuse to create without any key provided.
@@ -858,12 +858,12 @@ void TestCli::testDatabaseEdit()
 {
     TemporaryFile firstKeyFile;
     firstKeyFile.open();
-    firstKeyFile.write(QString("keyFilePassword").toLatin1());
+    firstKeyFile.write(QStringLiteral("keyFilePassword").toLatin1());
     firstKeyFile.close();
 
     TemporaryFile secondKeyFile;
     secondKeyFile.open();
-    secondKeyFile.write(QString("newKeyFilePassword").toLatin1());
+    secondKeyFile.write(QStringLiteral("newKeyFilePassword").toLatin1());
     secondKeyFile.close();
 
     QScopedPointer<QTemporaryDir> testDir(new QTemporaryDir());
@@ -1066,7 +1066,7 @@ void TestCli::testDiceware()
     TemporaryFile wordFile;
     wordFile.open();
     for (int i = 0; i < 4500; ++i) {
-        wordFile.write(QString("word" + QString::number(i) + "\n").toLatin1());
+        wordFile.write(QStringLiteral("word" + QString::number(i) + "\n").toLatin1());
     }
     wordFile.close();
 
@@ -1082,7 +1082,7 @@ void TestCli::testDiceware()
     TemporaryFile smallWordFile;
     smallWordFile.open();
     for (int i = 0; i < 50; ++i) {
-        smallWordFile.write(QString("word" + QString::number(i) + "\n").toLatin1());
+        smallWordFile.write(QStringLiteral("word" + QString::number(i) + "\n").toLatin1());
     }
     smallWordFile.close();
 
@@ -1114,10 +1114,10 @@ void TestCli::testEdit()
     auto db = readDatabase();
     auto* entry = db->rootGroup()->findEntryByPath("/newtitle");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser"));
-    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
-    QCOMPARE(entry->password(), QString("Password"));
-    QCOMPARE(entry->notes(), QString("newnotes"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser"));
+    QCOMPARE(entry->url(), QStringLiteral("https://otherurl.example.com/"));
+    QCOMPARE(entry->password(), QStringLiteral("Password"));
+    QCOMPARE(entry->notes(), QStringLiteral("newnotes"));
 
     // Quiet option
     setInput("a");
@@ -1130,19 +1130,19 @@ void TestCli::testEdit()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/newertitle");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser"));
-    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser"));
+    QCOMPARE(entry->url(), QStringLiteral("https://otherurl.example.com/"));
     QVERIFY(!entry->password().isEmpty());
-    QVERIFY(entry->password() != QString("Password"));
+    QVERIFY(entry->password() != QStringLiteral("Password"));
 
     setInput("a");
     execCmd(editCmd, {"edit", "-g", "-L", "34", "-t", "evennewertitle", m_dbFile->fileName(), "/newertitle"});
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/evennewertitle");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("newuser"));
-    QCOMPARE(entry->url(), QString("https://otherurl.example.com/"));
-    QVERIFY(entry->password() != QString("Password"));
+    QCOMPARE(entry->username(), QStringLiteral("newuser"));
+    QCOMPARE(entry->url(), QStringLiteral("https://otherurl.example.com/"));
+    QVERIFY(entry->password() != QStringLiteral("Password"));
     QCOMPARE(entry->password().size(), 34);
     QRegularExpression defaultPasswordClassesRegex("^[a-zA-Z0-9]+$");
     QVERIFY(defaultPasswordClassesRegex.match(entry->password()).hasMatch());
@@ -1174,7 +1174,7 @@ void TestCli::testEdit()
     QVERIFY(db);
     entry = db->rootGroup()->findEntryByPath("/evennewertitle");
     QVERIFY(entry);
-    QCOMPARE(entry->password(), QString("newpassword"));
+    QCOMPARE(entry->password(), QStringLiteral("newpassword"));
 
     // with line break in notes
     setInput("a");
@@ -1182,7 +1182,7 @@ void TestCli::testEdit()
     db = readDatabase();
     entry = db->rootGroup()->findEntryByPath("/evennewertitle");
     QVERIFY(entry);
-    QCOMPARE(entry->notes(), QString("testing\nline breaks"));
+    QCOMPARE(entry->notes(), QStringLiteral("testing\nline breaks"));
 }
 
 void TestCli::testEstimate_data()
@@ -1305,7 +1305,7 @@ void TestCli::testExport()
 
     auto* entry = db->rootGroup()->findEntryByPath("/Sample Entry");
     QVERIFY(entry);
-    QCOMPARE(entry->password(), QString("Password"));
+    QCOMPARE(entry->password(), QStringLiteral("Password"));
 
     // Quiet option
     QScopedPointer<Database> dbQuiet(new Database());
@@ -1422,13 +1422,13 @@ void TestCli::testImport()
     QVERIFY(db);
     auto* entry = db->rootGroup()->findEntryByPath("/Sample Entry 1");
     QVERIFY(entry);
-    QCOMPARE(entry->username(), QString("User Name"));
+    QCOMPARE(entry->username(), QStringLiteral("User Name"));
 
     // Should refuse to create the database if it already exists.
     execCmd(importCmd, {"import", m_xmlFile->fileName(), databaseFilename});
     // Output should be empty when there is an error.
     QCOMPARE(m_stdout->readAll(), QByteArray());
-    QString errorMessage = QString("File " + databaseFilename + " already exists.\n");
+    QString errorMessage = QStringLiteral("File " + databaseFilename + " already exists.\n");
     QCOMPARE(m_stderr->readAll(), errorMessage.toUtf8());
 
     // Testing import with non-existing keyfile
@@ -1505,7 +1505,7 @@ void TestCli::testKeyFileOption()
 {
     List listCmd;
 
-    QString keyFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/KeyFileProtected.key"));
+    QString keyFilePath(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/KeyFileProtected.key"));
     setInput("a");
     execCmd(listCmd, {"ls", "-k", keyFilePath, m_keyFileProtectedDbFile->fileName()});
     m_stderr->readLine(); // Skip password prompt
@@ -1532,7 +1532,7 @@ void TestCli::testNoPasswordOption()
 {
     List listCmd;
 
-    QString keyFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/KeyFileProtectedNoPassword.key"));
+    QString keyFilePath(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/KeyFileProtectedNoPassword.key"));
     execCmd(listCmd, {"ls", "-k", keyFilePath, "--no-password", m_keyFileProtectedNoPasswordDbFile->fileName()});
     // Expecting no password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());
@@ -1687,15 +1687,15 @@ void TestCli::testMerge()
     QVERIFY(outLines1.at(0).contains("Overwriting Internet"));
     QVERIFY(outLines1.at(1).contains("Creating missing Some Website"));
     QCOMPARE(outLines1.at(2),
-             QString("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile1.fileName()).toUtf8());
+             QStringLiteral("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile1.fileName()).toUtf8());
 
     auto mergedDb = QSharedPointer<Database>::create();
     QVERIFY(mergedDb->open(targetFile1.fileName(), oldKey));
 
     auto* entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
     QVERIFY(entry1);
-    QCOMPARE(entry1->title(), QString("Some Website"));
-    QCOMPARE(entry1->password(), QString("secretsecretsecret"));
+    QCOMPARE(entry1->title(), QStringLiteral("Some Website"));
+    QCOMPARE(entry1->password(), QStringLiteral("secretsecretsecret"));
 
     // the dry run option should not modify the target database.
     setInput("a");
@@ -1726,15 +1726,15 @@ void TestCli::testMerge()
     execCmd(mergeCmd, {"merge", targetFile3.fileName(), sourceFile.fileName()});
     QList<QByteArray> outLines3 = m_stdout->readAll().split('\n');
     QCOMPARE(outLines3.at(2),
-             QString("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile3.fileName()).toUtf8());
+             QStringLiteral("Successfully merged %1 into %2.").arg(sourceFile.fileName(), targetFile3.fileName()).toUtf8());
 
     mergedDb = QSharedPointer<Database>::create();
     QVERIFY(mergedDb->open(targetFile3.fileName(), key));
 
     entry1 = mergedDb->rootGroup()->findEntryByPath("/Internet/Some Website");
     QVERIFY(entry1);
-    QCOMPARE(entry1->title(), QString("Some Website"));
-    QCOMPARE(entry1->password(), QString("secretsecretsecret"));
+    QCOMPARE(entry1->title(), QStringLiteral("Some Website"));
+    QCOMPARE(entry1->password(), QStringLiteral("secretsecretsecret"));
 
     // making sure that the message is different if the database was not
     // modified by the merge operation.
@@ -1834,7 +1834,7 @@ void TestCli::testMergeWithKeys()
 
     QList<QByteArray> lines = m_stdout->readAll().split('\n');
     QVERIFY(lines.contains(
-        QString("Successfully merged %1 into %2.").arg(sourceDatabaseFilename, targetDatabaseFilename).toUtf8()));
+        QStringLiteral("Successfully merged %1 into %2.").arg(sourceDatabaseFilename, targetDatabaseFilename).toUtf8()));
 }
 
 void TestCli::testMove()
@@ -1904,7 +1904,7 @@ void TestCli::testRemove()
     auto readBackDb = readDatabase();
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));
-    QVERIFY(readBackDb->rootGroup()->findEntryByPath(QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
+    QVERIFY(readBackDb->rootGroup()->findEntryByPath(QStringLiteral("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
 
     // try again, this time without recycle bin
     setInput("a");
@@ -1915,7 +1915,7 @@ void TestCli::testRemove()
     readBackDb = readDatabase(fileCopy.fileName(), "a");
     QVERIFY(readBackDb);
     QVERIFY(!readBackDb->rootGroup()->findEntryByPath("/Sample Entry"));
-    QVERIFY(!readBackDb->rootGroup()->findEntryByPath(QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
+    QVERIFY(!readBackDb->rootGroup()->findEntryByPath(QStringLiteral("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
 
     // finally, try deleting a non-existent entry
     setInput("a");
@@ -1991,17 +1991,17 @@ void TestCli::testRemoveQuiet()
     QVERIFY(db);
 
     QVERIFY(!db->rootGroup()->findEntryByPath("/Sample Entry"));
-    QVERIFY(db->rootGroup()->findEntryByPath(QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
+    QVERIFY(db->rootGroup()->findEntryByPath(QStringLiteral("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
 
     // remove the entry completely
     setInput("a");
-    execCmd(removeCmd, {"rm", "-q", m_dbFile->fileName(), QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))});
+    execCmd(removeCmd, {"rm", "-q", m_dbFile->fileName(), QStringLiteral("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))});
     QCOMPARE(m_stderr->readAll(), QByteArray());
     QCOMPARE(m_stdout->readAll(), QByteArray());
 
     db = readDatabase();
     QVERIFY(!db->rootGroup()->findEntryByPath("/Sample Entry"));
-    QVERIFY(!db->rootGroup()->findEntryByPath(QString("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
+    QVERIFY(!db->rootGroup()->findEntryByPath(QStringLiteral("/%1/Sample Entry").arg(Group::tr("Recycle Bin"))));
 }
 
 void TestCli::testSearch()
@@ -2290,7 +2290,7 @@ void TestCli::testYubiKeyOption()
     execCmd(listCmd,
             {"ls",
              "-y",
-             QString("%1:%2").arg(QString::number(pKey.second), QString::number(pKey.first)),
+             QStringLiteral("%1:%2").arg(QString::number(pKey.second), QString::number(pKey.first)),
              m_yubiKeyProtectedDbFile->fileName()});
     m_stderr->readLine(); // skip password prompt
     QCOMPARE(m_stderr->readAll(), QByteArray());

--- a/tests/TestConfig.cpp
+++ b/tests/TestConfig.cpp
@@ -24,7 +24,7 @@
 
 QTEST_GUILESS_MAIN(TestConfig)
 
-const QString oldTrueConfigPath = QString(KEEPASSX_TEST_DATA_DIR).append("/OutdatedConfig.ini");
+const QString oldTrueConfigPath = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/OutdatedConfig.ini");
 
 // upgrade config file with deprecated settings (all of which are set to non-default values)
 void TestConfig::testUpgrade()

--- a/tests/TestCryptoHash.cpp
+++ b/tests/TestCryptoHash.cpp
@@ -35,13 +35,13 @@ void TestCryptoHash::test()
     QCOMPARE(cryptoHash1.result(),
              QByteArray::fromHex("e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"));
 
-    QByteArray source2 = QString("KeePassX").toLatin1();
+    QByteArray source2 = QStringLiteral("KeePassX").toLatin1();
     QByteArray result2 = CryptoHash::hash(source2, CryptoHash::Sha256);
     QCOMPARE(result2, QByteArray::fromHex("0b56e5f65263e747af4a833bd7dd7ad26a64d7a4de7c68e52364893dca0766b4"));
 
     CryptoHash cryptoHash3(CryptoHash::Sha256);
-    cryptoHash3.addData(QString("KeePa").toLatin1());
-    cryptoHash3.addData(QString("ssX").toLatin1());
+    cryptoHash3.addData(QStringLiteral("KeePa").toLatin1());
+    cryptoHash3.addData(QStringLiteral("ssX").toLatin1());
     QCOMPARE(cryptoHash3.result(),
              QByteArray::fromHex("0b56e5f65263e747af4a833bd7dd7ad26a64d7a4de7c68e52364893dca0766b4"));
 
@@ -56,8 +56,8 @@ void TestCryptoHash::test()
                                  "d777970e282871c25a549a2763e5b724794f312c97021c42f91d"));
 
     CryptoHash cryptoHash4(CryptoHash::Sha512);
-    cryptoHash4.addData(QString("KeePa").toLatin1());
-    cryptoHash4.addData(QString("ssX").toLatin1());
+    cryptoHash4.addData(QStringLiteral("KeePa").toLatin1());
+    cryptoHash4.addData(QStringLiteral("ssX").toLatin1());
     QCOMPARE(cryptoHash4.result(),
              QByteArray::fromHex("0d41b612584ed39ff72944c29494573e40f4bb95283455fae2e0be1e3565aa9f48057d59e6ffd777970e2"
                                  "82871c25a549a2763e5b724794f312c97021c42f91d"));

--- a/tests/TestCsvExporter.cpp
+++ b/tests/TestCsvExporter.cpp
@@ -29,7 +29,7 @@
 QTEST_GUILESS_MAIN(TestCsvExporter)
 
 const QString TestCsvExporter::ExpectedHeaderLine =
-    QString("\"Group\",\"Title\",\"Username\",\"Password\",\"URL\",\"Notes\",\"TOTP\",\"Icon\",\"Last "
+    QStringLiteral("\"Group\",\"Title\",\"Username\",\"Password\",\"URL\",\"Notes\",\"TOTP\",\"Icon\",\"Last "
             "Modified\",\"Created\"\n");
 
 void TestCsvExporter::init()

--- a/tests/TestCsvParser.cpp
+++ b/tests/TestCsvParser.cpp
@@ -333,7 +333,7 @@ void TestCsvParser::testUnicode()
     // ERROR QChar g("\u20AC");
     parser->setFieldSeparator(QChar('A'));
     QTextStream out(file.data());
-    out << QString("€1A2śA\"3śAż\"Ażac");
+    out << QStringLiteral("€1A2śA\"3śAż\"Ażac");
 
     QVERIFY(parser->parse(file.data()));
     t = parser->getCsvTable();

--- a/tests/TestDatabase.cpp
+++ b/tests/TestDatabase.cpp
@@ -124,7 +124,7 @@ void TestDatabase::testSaveAs()
     // Negative case when try to save not initialized DB.
     db->releaseData();
     QVERIFY2(!db->saveAs(newDbFileName, Database::Atomic, QString(), &error), error.toLatin1());
-    QCOMPARE(error, QString("Could not save, database has not been initialized!"));
+    QCOMPARE(error, QStringLiteral("Could not save, database has not been initialized!"));
 }
 
 void TestDatabase::testSignals()
@@ -168,7 +168,7 @@ void TestDatabase::testSignals()
 
 void TestDatabase::testEmptyRecycleBinOnDisabled()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinDisabled.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinDisabled.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
@@ -183,7 +183,7 @@ void TestDatabase::testEmptyRecycleBinOnDisabled()
 
 void TestDatabase::testEmptyRecycleBinOnNotCreated()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinNotYetCreated.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinNotYetCreated.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
@@ -198,7 +198,7 @@ void TestDatabase::testEmptyRecycleBinOnNotCreated()
 
 void TestDatabase::testEmptyRecycleBinOnEmpty()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinEmpty.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinEmpty.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
@@ -213,7 +213,7 @@ void TestDatabase::testEmptyRecycleBinOnEmpty()
 
 void TestDatabase::testEmptyRecycleBinWithHierarchicalData()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinWithData.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/RecycleBinWithData.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("123"));
     auto db = QSharedPointer<Database>::create();
@@ -254,6 +254,6 @@ void TestDatabase::testCustomIcons()
     db.metadata()->addCustomIcon(uuid2, icon2, "Test", date);
     iconData = db.metadata()->customIcon(uuid2);
     QCOMPARE(iconData.data, icon2);
-    QCOMPARE(iconData.name, QString("Test"));
+    QCOMPARE(iconData.name, QStringLiteral("Test"));
     QCOMPARE(iconData.lastModified, date);
 }

--- a/tests/TestDeletedObjects.cpp
+++ b/tests/TestDeletedObjects.cpp
@@ -89,7 +89,7 @@ void TestDeletedObjects::testDeletedObjectsFromFile()
 {
     KdbxXmlReader reader(KeePass2::FILE_VERSION_3_1);
     reader.setStrictMode(true);
-    QString xmlFile = QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml");
+    QString xmlFile = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml");
     auto db = reader.readDatabase(xmlFile);
 
     createAndDelete(db, 2);

--- a/tests/TestEntry.cpp
+++ b/tests/TestEntry.cpp
@@ -69,17 +69,17 @@ void TestEntry::testCopyDataFrom()
     QScopedPointer<Entry> entry2(new Entry());
     entry2->copyDataFrom(entry.data());
 
-    QCOMPARE(entry2->title(), QString("testtitle"));
-    QCOMPARE(entry2->attributes()->value("attr1"), QString("abc"));
-    QCOMPARE(entry2->attributes()->value("attr2"), QString("def"));
+    QCOMPARE(entry2->title(), QStringLiteral("testtitle"));
+    QCOMPARE(entry2->attributes()->value("attr1"), QStringLiteral("abc"));
+    QCOMPARE(entry2->attributes()->value("attr2"), QStringLiteral("def"));
 
     QCOMPARE(entry2->attachments()->keys().size(), 2);
     QCOMPARE(entry2->attachments()->value("test"), QByteArray("123"));
     QCOMPARE(entry2->attachments()->value("test2"), QByteArray("456"));
 
     QCOMPARE(entry2->autoTypeAssociations()->size(), 2);
-    QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QString("1"));
-    QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QString("3"));
+    QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QStringLiteral("1"));
+    QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QStringLiteral("3"));
 }
 
 void TestEntry::testClone()
@@ -97,14 +97,14 @@ void TestEntry::testClone()
 
     QScopedPointer<Entry> entryCloneNone(entryOrg->clone(Entry::CloneNoFlags));
     QCOMPARE(entryCloneNone->uuid(), entryOrg->uuid());
-    QCOMPARE(entryCloneNone->title(), QString("New Title"));
+    QCOMPARE(entryCloneNone->title(), QStringLiteral("New Title"));
     QCOMPARE(entryCloneNone->historyItems().size(), 0);
     QCOMPARE(entryCloneNone->timeInfo().creationTime(), entryOrg->timeInfo().creationTime());
 
     QScopedPointer<Entry> entryCloneNewUuid(entryOrg->clone(Entry::CloneNewUuid));
     QVERIFY(entryCloneNewUuid->uuid() != entryOrg->uuid());
     QVERIFY(!entryCloneNewUuid->uuid().isNull());
-    QCOMPARE(entryCloneNewUuid->title(), QString("New Title"));
+    QCOMPARE(entryCloneNewUuid->title(), QStringLiteral("New Title"));
     QCOMPARE(entryCloneNewUuid->historyItems().size(), 0);
     QCOMPARE(entryCloneNewUuid->timeInfo().creationTime(), entryOrg->timeInfo().creationTime());
 
@@ -114,13 +114,13 @@ void TestEntry::testClone()
 
     QScopedPointer<Entry> entryCloneRename(entryOrg->clone(Entry::CloneRenameTitle));
     QCOMPARE(entryCloneRename->uuid(), entryOrg->uuid());
-    QCOMPARE(entryCloneRename->title(), QString("New Title - Clone"));
+    QCOMPARE(entryCloneRename->title(), QStringLiteral("New Title - Clone"));
     // Cloning should not modify time info unless explicitly requested
     QCOMPARE(entryCloneRename->timeInfo(), entryOrg->timeInfo());
 
     QScopedPointer<Entry> entryCloneResetTime(entryOrg->clone(Entry::CloneResetTimeInfo));
     QCOMPARE(entryCloneResetTime->uuid(), entryOrg->uuid());
-    QCOMPARE(entryCloneResetTime->title(), QString("New Title"));
+    QCOMPARE(entryCloneResetTime->title(), QStringLiteral("New Title"));
     QCOMPARE(entryCloneResetTime->historyItems().size(), 0);
     QVERIFY(entryCloneResetTime->timeInfo().creationTime() != entryOrg->timeInfo().creationTime());
 
@@ -134,9 +134,9 @@ void TestEntry::testClone()
 
     QScopedPointer<Entry> entryCloneHistory(entryOrg->clone(Entry::CloneIncludeHistory | Entry::CloneResetTimeInfo));
     QCOMPARE(entryCloneHistory->uuid(), entryOrg->uuid());
-    QCOMPARE(entryCloneHistory->title(), QString("New Title"));
+    QCOMPARE(entryCloneHistory->title(), QStringLiteral("New Title"));
     QCOMPARE(entryCloneHistory->historyItems().size(), entryOrg->historyItems().size());
-    QCOMPARE(entryCloneHistory->historyItems().at(0)->title(), QString("Original Title"));
+    QCOMPARE(entryCloneHistory->historyItems().at(0)->title(), QStringLiteral("Original Title"));
     QVERIFY(entryCloneHistory->timeInfo().creationTime() != entryOrg->timeInfo().creationTime());
     // Timeinfo of history items should not be modified
     QList<Entry*> entryOrgHistory = entryOrg->historyItems(), clonedHistory = entryCloneHistory->historyItems();
@@ -153,7 +153,7 @@ void TestEntry::testClone()
     Entry* entryCloneUserRef = entryOrgClone->clone(Entry::CloneUserAsRef);
     entryCloneUserRef->setGroup(db.rootGroup());
     QCOMPARE(entryCloneUserRef->uuid(), entryOrgClone->uuid());
-    QCOMPARE(entryCloneUserRef->title(), QString("New Title"));
+    QCOMPARE(entryCloneUserRef->title(), QStringLiteral("New Title"));
     QCOMPARE(entryCloneUserRef->historyItems().size(), 0);
     QCOMPARE(entryCloneUserRef->timeInfo().creationTime(), entryOrgClone->timeInfo().creationTime());
     QVERIFY(entryCloneUserRef->attributes()->isReference(EntryAttributes::UserNameKey));
@@ -162,7 +162,7 @@ void TestEntry::testClone()
     Entry* entryClonePassRef = entryOrgClone->clone(Entry::ClonePassAsRef);
     entryClonePassRef->setGroup(db.rootGroup());
     QCOMPARE(entryClonePassRef->uuid(), entryOrgClone->uuid());
-    QCOMPARE(entryClonePassRef->title(), QString("New Title"));
+    QCOMPARE(entryClonePassRef->title(), QStringLiteral("New Title"));
     QCOMPARE(entryClonePassRef->historyItems().size(), 0);
     QCOMPARE(entryClonePassRef->timeInfo().creationTime(), entryOrgClone->timeInfo().creationTime());
     QVERIFY(entryClonePassRef->attributes()->isReference(EntryAttributes::PasswordKey));
@@ -182,7 +182,7 @@ void TestEntry::testResolveUrl()
     QString noUrl("random text inserted here");
 
     // Test standard URL's
-    QCOMPARE(entry->resolveUrl(""), QString(""));
+    QCOMPARE(entry->resolveUrl(""), QString());
     QCOMPARE(entry->resolveUrl(testUrl), "https://" + testUrl);
     QCOMPARE(entry->resolveUrl("http://" + testUrl), "http://" + testUrl);
     // Test file:// URL's
@@ -191,15 +191,15 @@ void TestEntry::testResolveUrl()
     QCOMPARE(entry->resolveUrl("file:///" + testFileWindows), "file:///" + testFileWindows);
     QCOMPARE(entry->resolveUrl(testFileWindows), "file:///" + testFileWindows);
     // Test cmd:// with no URL
-    QCOMPARE(entry->resolveUrl("cmd://firefox"), QString(""));
-    QCOMPARE(entry->resolveUrl("cmd://firefox --no-url"), QString(""));
+    QCOMPARE(entry->resolveUrl("cmd://firefox"), QString());
+    QCOMPARE(entry->resolveUrl("cmd://firefox --no-url"), QString());
     // Test cmd:// with URL's
     QCOMPARE(entry->resolveUrl(testCmd), "https://" + testUrl);
     QCOMPARE(entry->resolveUrl(testComplexCmd), "http://" + testUrl);
     // Test non-http URL
-    QCOMPARE(entry->resolveUrl(nonHttpUrl), QString(""));
+    QCOMPARE(entry->resolveUrl(nonHttpUrl), QString());
     // Test no URL
-    QCOMPARE(entry->resolveUrl(noUrl), QString(""));
+    QCOMPARE(entry->resolveUrl(noUrl), QString());
 }
 
 void TestEntry::testResolveUrlPlaceholders()
@@ -245,14 +245,14 @@ void TestEntry::testResolveRecursivePlaceholders()
     entry1->setPassword("{URL}");
     entry1->setUrl("{S:CustomTitle}");
     entry1->attributes()->set("CustomTitle", "RecursiveValue");
-    QCOMPARE(entry1->resolveMultiplePlaceholders(entry1->title()), QString("RecursiveValue"));
+    QCOMPARE(entry1->resolveMultiplePlaceholders(entry1->title()), QStringLiteral("RecursiveValue"));
 
     auto* entry2 = new Entry();
     entry2->setGroup(root);
     entry2->setUuid(QUuid::createUuid());
     entry2->setTitle("Entry2Title");
     entry2->setUsername("{S:CustomUserNameAttribute}");
-    entry2->setPassword(QString("{REF:P@I:%1}").arg(entry1->uuidToHex()));
+    entry2->setPassword(QStringLiteral("{REF:P@I:%1}").arg(entry1->uuidToHex()));
     entry2->setUrl("http://{S:IpAddress}:{S:Port}/{S:Uri}");
     entry2->attributes()->set("CustomUserNameAttribute", "CustomUserNameValue");
     entry2->attributes()->set("IpAddress", "127.0.0.1");
@@ -262,28 +262,28 @@ void TestEntry::testResolveRecursivePlaceholders()
     auto* entry3 = new Entry();
     entry3->setGroup(root);
     entry3->setUuid(QUuid::createUuid());
-    entry3->setTitle(QString("{REF:T@I:%1}").arg(entry2->uuidToHex()));
-    entry3->setUsername(QString("{REF:U@I:%1}").arg(entry2->uuidToHex()));
-    entry3->setPassword(QString("{REF:P@I:%1}").arg(entry2->uuidToHex()));
-    entry3->setUrl(QString("{REF:A@I:%1}").arg(entry2->uuidToHex()));
+    entry3->setTitle(QStringLiteral("{REF:T@I:%1}").arg(entry2->uuidToHex()));
+    entry3->setUsername(QStringLiteral("{REF:U@I:%1}").arg(entry2->uuidToHex()));
+    entry3->setPassword(QStringLiteral("{REF:P@I:%1}").arg(entry2->uuidToHex()));
+    entry3->setUrl(QStringLiteral("{REF:A@I:%1}").arg(entry2->uuidToHex()));
 
-    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->title()), QString("Entry2Title"));
-    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->username()), QString("CustomUserNameValue"));
-    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->password()), QString("RecursiveValue"));
-    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->url()), QString("http://127.0.0.1:1234/uri/path"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->title()), QStringLiteral("Entry2Title"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->username()), QStringLiteral("CustomUserNameValue"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->password()), QStringLiteral("RecursiveValue"));
+    QCOMPARE(entry3->resolveMultiplePlaceholders(entry3->url()), QStringLiteral("http://127.0.0.1:1234/uri/path"));
 
     auto* entry4 = new Entry();
     entry4->setGroup(root);
     entry4->setUuid(QUuid::createUuid());
-    entry4->setTitle(QString("{REF:T@I:%1}").arg(entry3->uuidToHex()));
-    entry4->setUsername(QString("{REF:U@I:%1}").arg(entry3->uuidToHex()));
-    entry4->setPassword(QString("{REF:P@I:%1}").arg(entry3->uuidToHex()));
-    entry4->setUrl(QString("{REF:A@I:%1}").arg(entry3->uuidToHex()));
+    entry4->setTitle(QStringLiteral("{REF:T@I:%1}").arg(entry3->uuidToHex()));
+    entry4->setUsername(QStringLiteral("{REF:U@I:%1}").arg(entry3->uuidToHex()));
+    entry4->setPassword(QStringLiteral("{REF:P@I:%1}").arg(entry3->uuidToHex()));
+    entry4->setUrl(QStringLiteral("{REF:A@I:%1}").arg(entry3->uuidToHex()));
 
-    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->title()), QString("Entry2Title"));
-    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->username()), QString("CustomUserNameValue"));
-    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->password()), QString("RecursiveValue"));
-    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->url()), QString("http://127.0.0.1:1234/uri/path"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->title()), QStringLiteral("Entry2Title"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->username()), QStringLiteral("CustomUserNameValue"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->password()), QStringLiteral("RecursiveValue"));
+    QCOMPARE(entry4->resolveMultiplePlaceholders(entry4->url()), QStringLiteral("http://127.0.0.1:1234/uri/path"));
 
     auto* entry5 = new Entry();
     entry5->setGroup(root);
@@ -301,29 +301,29 @@ void TestEntry::testResolveRecursivePlaceholders()
 
     const QString url("http://username:password@host.org:2017/some/path?q=e&t=s#fragment");
     QCOMPARE(entry5->resolveMultiplePlaceholders(entry5->url()), url);
-    QCOMPARE(entry5->resolveMultiplePlaceholders(entry5->title()), QString("title+/some/path+fragment+title"));
+    QCOMPARE(entry5->resolveMultiplePlaceholders(entry5->title()), QStringLiteral("title+/some/path+fragment+title"));
 
     auto* entry6 = new Entry();
     entry6->setGroup(root);
     entry6->setUuid(QUuid::createUuid());
-    entry6->setTitle(QString("{REF:T@I:%1}").arg(entry3->uuidToHex()));
-    entry6->setUsername(QString("{TITLE}"));
-    entry6->setPassword(QString("{PASSWORD}"));
+    entry6->setTitle(QStringLiteral("{REF:T@I:%1}").arg(entry3->uuidToHex()));
+    entry6->setUsername(QStringLiteral("{TITLE}"));
+    entry6->setPassword(QStringLiteral("{PASSWORD}"));
 
-    QCOMPARE(entry6->resolvePlaceholder(entry6->title()), QString("Entry2Title"));
-    QCOMPARE(entry6->resolvePlaceholder(entry6->username()), QString("Entry2Title"));
-    QCOMPARE(entry6->resolvePlaceholder(entry6->password()), QString("{PASSWORD}"));
+    QCOMPARE(entry6->resolvePlaceholder(entry6->title()), QStringLiteral("Entry2Title"));
+    QCOMPARE(entry6->resolvePlaceholder(entry6->username()), QStringLiteral("Entry2Title"));
+    QCOMPARE(entry6->resolvePlaceholder(entry6->password()), QStringLiteral("{PASSWORD}"));
 
     auto* entry7 = new Entry();
     entry7->setGroup(root);
     entry7->setUuid(QUuid::createUuid());
-    entry7->setTitle(QString("{REF:T@I:%1} and something else").arg(entry3->uuidToHex()));
-    entry7->setUsername(QString("{TITLE}"));
-    entry7->setPassword(QString("PASSWORD"));
+    entry7->setTitle(QStringLiteral("{REF:T@I:%1} and something else").arg(entry3->uuidToHex()));
+    entry7->setUsername(QStringLiteral("{TITLE}"));
+    entry7->setPassword(QStringLiteral("PASSWORD"));
 
-    QCOMPARE(entry7->resolvePlaceholder(entry7->title()), QString("Entry2Title and something else"));
-    QCOMPARE(entry7->resolvePlaceholder(entry7->username()), QString("Entry2Title and something else"));
-    QCOMPARE(entry7->resolvePlaceholder(entry7->password()), QString("PASSWORD"));
+    QCOMPARE(entry7->resolvePlaceholder(entry7->title()), QStringLiteral("Entry2Title and something else"));
+    QCOMPARE(entry7->resolvePlaceholder(entry7->username()), QStringLiteral("Entry2Title and something else"));
+    QCOMPARE(entry7->resolvePlaceholder(entry7->password()), QStringLiteral("PASSWORD"));
 }
 
 void TestEntry::testResolveReferencePlaceholders()
@@ -371,74 +371,74 @@ void TestEntry::testResolveReferencePlaceholders()
     tstEntry->setGroup(root);
     tstEntry->setUuid(QUuid::createUuid());
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@I:%1}").arg(entry1->uuidToHex())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@T:%1}").arg(entry1->title())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@U:%1}").arg(entry1->username())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@P:%1}").arg(entry1->password())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@A:%1}").arg(entry1->url())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@N:%1}").arg(entry1->notes())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@I:%1}").arg(entry1->uuidToHex())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@T:%1}").arg(entry1->title())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@U:%1}").arg(entry1->username())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@P:%1}").arg(entry1->password())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@A:%1}").arg(entry1->url())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@N:%1}").arg(entry1->notes())), entry1->title());
     QCOMPARE(tstEntry->resolveMultiplePlaceholders(
-                 QString("{REF:T@O:%1}").arg(entry1->attributes()->value("CustomAttribute1"))),
+                 QStringLiteral("{REF:T@O:%1}").arg(entry1->attributes()->value("CustomAttribute1"))),
              entry1->title());
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@I:%1}").arg(entry1->uuidToHex())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@T:%1}").arg(entry1->title())), entry1->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:U@U:%1}").arg(entry1->username())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@I:%1}").arg(entry1->uuidToHex())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@T:%1}").arg(entry1->title())), entry1->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:U@U:%1}").arg(entry1->username())),
              entry1->username());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:P@P:%1}").arg(entry1->password())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:P@P:%1}").arg(entry1->password())),
              entry1->password());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:A@A:%1}").arg(entry1->url())), entry1->url());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:N@N:%1}").arg(entry1->notes())), entry1->notes());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:A@A:%1}").arg(entry1->url())), entry1->url());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:N@N:%1}").arg(entry1->notes())), entry1->notes());
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@I:%1}").arg(entry2->uuidToHex())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@T:%1}").arg(entry2->title())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@U:%1}").arg(entry2->username())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@P:%1}").arg(entry2->password())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@A:%1}").arg(entry2->url())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@N:%1}").arg(entry2->notes())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@I:%1}").arg(entry2->uuidToHex())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@T:%1}").arg(entry2->title())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@U:%1}").arg(entry2->username())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@P:%1}").arg(entry2->password())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@A:%1}").arg(entry2->url())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@N:%1}").arg(entry2->notes())), entry2->title());
     QCOMPARE(tstEntry->resolveMultiplePlaceholders(
-                 QString("{REF:T@O:%1}").arg(entry2->attributes()->value("CustomAttribute2"))),
+                 QStringLiteral("{REF:T@O:%1}").arg(entry2->attributes()->value("CustomAttribute2"))),
              entry2->title());
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@T:%1}").arg(entry2->title())), entry2->title());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:U@U:%1}").arg(entry2->username())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@T:%1}").arg(entry2->title())), entry2->title());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:U@U:%1}").arg(entry2->username())),
              entry2->username());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:P@P:%1}").arg(entry2->password())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:P@P:%1}").arg(entry2->password())),
              entry2->password());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:A@A:%1}").arg(entry2->url())), entry2->url());
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:N@N:%1}").arg(entry2->notes())), entry2->notes());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:A@A:%1}").arg(entry2->url())), entry2->url());
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:N@N:%1}").arg(entry2->notes())), entry2->notes());
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@I:%1}").arg(entry3->uuidToHex())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@I:%1}").arg(entry3->uuidToHex())),
              entry3->attributes()->value("AttributeTitle"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:U@I:%1}").arg(entry3->uuidToHex())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:U@I:%1}").arg(entry3->uuidToHex())),
              entry3->attributes()->value("AttributeUsername"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:P@I:%1}").arg(entry3->uuidToHex())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:P@I:%1}").arg(entry3->uuidToHex())),
              entry3->attributes()->value("AttributePassword"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:A@I:%1}").arg(entry3->uuidToHex())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:A@I:%1}").arg(entry3->uuidToHex())),
              entry3->attributes()->value("AttributeUrl"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:N@I:%1}").arg(entry3->uuidToHex())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:N@I:%1}").arg(entry3->uuidToHex())),
              entry3->attributes()->value("AttributeNotes"));
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:T@I:%1}").arg(entry3->uuidToHex().toUpper())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:T@I:%1}").arg(entry3->uuidToHex().toUpper())),
              entry3->attributes()->value("AttributeTitle"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:U@I:%1}").arg(entry3->uuidToHex().toUpper())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:U@I:%1}").arg(entry3->uuidToHex().toUpper())),
              entry3->attributes()->value("AttributeUsername"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:P@I:%1}").arg(entry3->uuidToHex().toUpper())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:P@I:%1}").arg(entry3->uuidToHex().toUpper())),
              entry3->attributes()->value("AttributePassword"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:A@I:%1}").arg(entry3->uuidToHex().toUpper())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:A@I:%1}").arg(entry3->uuidToHex().toUpper())),
              entry3->attributes()->value("AttributeUrl"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:N@I:%1}").arg(entry3->uuidToHex().toUpper())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:N@I:%1}").arg(entry3->uuidToHex().toUpper())),
              entry3->attributes()->value("AttributeNotes"));
 
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:t@i:%1}").arg(entry3->uuidToHex().toLower())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:t@i:%1}").arg(entry3->uuidToHex().toLower())),
              entry3->attributes()->value("AttributeTitle"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:u@i:%1}").arg(entry3->uuidToHex().toLower())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:u@i:%1}").arg(entry3->uuidToHex().toLower())),
              entry3->attributes()->value("AttributeUsername"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:p@i:%1}").arg(entry3->uuidToHex().toLower())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:p@i:%1}").arg(entry3->uuidToHex().toLower())),
              entry3->attributes()->value("AttributePassword"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:a@i:%1}").arg(entry3->uuidToHex().toLower())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:a@i:%1}").arg(entry3->uuidToHex().toLower())),
              entry3->attributes()->value("AttributeUrl"));
-    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QString("{REF:n@i:%1}").arg(entry3->uuidToHex().toLower())),
+    QCOMPARE(tstEntry->resolveMultiplePlaceholders(QStringLiteral("{REF:n@i:%1}").arg(entry3->uuidToHex().toLower())),
              entry3->attributes()->value("AttributeNotes"));
 }
 

--- a/tests/TestEntryModel.cpp
+++ b/tests/TestEntryModel.cpp
@@ -151,7 +151,7 @@ void TestEntryModel::testAttachmentsModel()
     entryAttachments->set("2nd", QByteArray("7890"));
 
     const int firstRow = 0;
-    QCOMPARE(model->data(model->index(firstRow, EntryAttachmentsModel::NameColumn)).toString(), QString("2nd"));
+    QCOMPARE(model->data(model->index(firstRow, EntryAttachmentsModel::NameColumn)).toString(), QStringLiteral("2nd"));
     QCOMPARE(model->data(model->index(firstRow, EntryAttachmentsModel::SizeColumn), Qt::EditRole).toInt(), 4);
 
     entryAttachments->remove("first");
@@ -195,7 +195,7 @@ void TestEntryModel::testAttributesModel()
     entryAttributes->set("2nd", "456");
     entryAttributes->set("2nd", "789");
 
-    QCOMPARE(model->data(model->index(0, 0)).toString(), QString("2nd"));
+    QCOMPARE(model->data(model->index(0, 0)).toString(), QStringLiteral("2nd"));
 
     entryAttributes->remove("first");
 
@@ -280,14 +280,14 @@ void TestEntryModel::testAutoTypeAssociationsModel()
     associations->add(assoc);
 
     QCOMPARE(model->rowCount(), 1);
-    QCOMPARE(model->data(model->index(0, 0)).toString(), QString("1"));
-    QCOMPARE(model->data(model->index(0, 1)).toString(), QString("2"));
+    QCOMPARE(model->data(model->index(0, 0)).toString(), QStringLiteral("1"));
+    QCOMPARE(model->data(model->index(0, 1)).toString(), QStringLiteral("2"));
 
     assoc.window = "3";
     assoc.sequence = "4";
     associations->update(0, assoc);
-    QCOMPARE(model->data(model->index(0, 0)).toString(), QString("3"));
-    QCOMPARE(model->data(model->index(0, 1)).toString(), QString("4"));
+    QCOMPARE(model->data(model->index(0, 0)).toString(), QStringLiteral("3"));
+    QCOMPARE(model->data(model->index(0, 1)).toString(), QStringLiteral("4"));
 
     associations->add(assoc);
     associations->remove(0);

--- a/tests/TestEntrySearcher.cpp
+++ b/tests/TestEntrySearcher.cpp
@@ -202,21 +202,21 @@ void TestEntrySearcher::testSearchTermParser()
     QCOMPARE(terms.length(), 5);
 
     QCOMPARE(terms[0].field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[0].word, QString("test"));
+    QCOMPARE(terms[0].word, QStringLiteral("test"));
     QCOMPARE(terms[0].exclude, true);
 
     QCOMPARE(terms[1].field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[1].word, QString("quoted \"string\""));
+    QCOMPARE(terms[1].word, QStringLiteral("quoted \"string\""));
     QCOMPARE(terms[1].exclude, false);
 
     QCOMPARE(terms[2].field, EntrySearcher::Field::Username);
-    QCOMPARE(terms[2].word, QString("user"));
+    QCOMPARE(terms[2].word, QStringLiteral("user"));
 
     QCOMPARE(terms[3].field, EntrySearcher::Field::Password);
-    QCOMPARE(terms[3].word, QString("test me"));
+    QCOMPARE(terms[3].word, QStringLiteral("test me"));
 
     QCOMPARE(terms[4].field, EntrySearcher::Field::Undefined);
-    QCOMPARE(terms[4].word, QString("noquote"));
+    QCOMPARE(terms[4].word, QStringLiteral("noquote"));
 
     // Test wildcard and regex search terms
     m_entrySearcher.parseSearchTerms("+url:*.google.com *user:\\d+\\w{2}");
@@ -225,10 +225,10 @@ void TestEntrySearcher::testSearchTermParser()
     QCOMPARE(terms.length(), 2);
 
     QCOMPARE(terms[0].field, EntrySearcher::Field::Url);
-    QCOMPARE(terms[0].regex.pattern(), QString("^(?:.*\\.google\\.com)$"));
+    QCOMPARE(terms[0].regex.pattern(), QStringLiteral("^(?:.*\\.google\\.com)$"));
 
     QCOMPARE(terms[1].field, EntrySearcher::Field::Username);
-    QCOMPARE(terms[1].regex.pattern(), QString("\\d+\\w{2}"));
+    QCOMPARE(terms[1].regex.pattern(), QStringLiteral("\\d+\\w{2}"));
 
     // Test custom attribute search terms
     m_entrySearcher.parseSearchTerms("+_abc:efg _def:\"ddd\"");
@@ -237,12 +237,12 @@ void TestEntrySearcher::testSearchTermParser()
     QCOMPARE(terms.length(), 2);
 
     QCOMPARE(terms[0].field, EntrySearcher::Field::AttributeValue);
-    QCOMPARE(terms[0].word, QString("abc"));
-    QCOMPARE(terms[0].regex.pattern(), QString("^(?:efg)$"));
+    QCOMPARE(terms[0].word, QStringLiteral("abc"));
+    QCOMPARE(terms[0].regex.pattern(), QStringLiteral("^(?:efg)$"));
 
     QCOMPARE(terms[1].field, EntrySearcher::Field::AttributeValue);
-    QCOMPARE(terms[1].word, QString("def"));
-    QCOMPARE(terms[1].regex.pattern(), QString("ddd"));
+    QCOMPARE(terms[1].word, QStringLiteral("def"));
+    QCOMPARE(terms[1].regex.pattern(), QStringLiteral("ddd"));
 }
 
 void TestEntrySearcher::testCustomAttributesAreSearched()

--- a/tests/TestGroup.cpp
+++ b/tests/TestGroup.cpp
@@ -378,26 +378,26 @@ void TestGroup::testClone()
     QVERIFY(!clonedGroup->parentGroup());
     QVERIFY(!clonedGroup->database());
     QVERIFY(clonedGroup->uuid() != originalGroup->uuid());
-    QCOMPARE(clonedGroup->name(), QString("Group"));
+    QCOMPARE(clonedGroup->name(), QStringLiteral("Group"));
     QCOMPARE(clonedGroup->iconNumber(), 42);
     QCOMPARE(clonedGroup->children().size(), 1);
     QCOMPARE(clonedGroup->entries().size(), 1);
 
     Entry* clonedGroupEntry = clonedGroup->entries().at(0);
     QVERIFY(clonedGroupEntry->uuid() != originalGroupEntry->uuid());
-    QCOMPARE(clonedGroupEntry->title(), QString("GroupEntry"));
+    QCOMPARE(clonedGroupEntry->title(), QStringLiteral("GroupEntry"));
     QCOMPARE(clonedGroupEntry->iconNumber(), 43);
     QCOMPARE(clonedGroupEntry->historyItems().size(), 0);
 
     Group* clonedSubGroup = clonedGroup->children().at(0);
     QVERIFY(clonedSubGroup->uuid() != subGroup->uuid());
-    QCOMPARE(clonedSubGroup->name(), QString("SubGroup"));
+    QCOMPARE(clonedSubGroup->name(), QStringLiteral("SubGroup"));
     QCOMPARE(clonedSubGroup->children().size(), 0);
     QCOMPARE(clonedSubGroup->entries().size(), 1);
 
     Entry* clonedSubGroupEntry = clonedSubGroup->entries().at(0);
     QVERIFY(clonedSubGroupEntry->uuid() != subGroupEntry->uuid());
-    QCOMPARE(clonedSubGroupEntry->title(), QString("SubGroupEntry"));
+    QCOMPARE(clonedSubGroupEntry->title(), QStringLiteral("SubGroupEntry"));
 
     QScopedPointer<Group> clonedGroupKeepUuid(originalGroup->clone(Entry::CloneNoFlags));
     QCOMPARE(clonedGroupKeepUuid->entries().at(0)->uuid(), originalGroupEntry->uuid());
@@ -477,7 +477,7 @@ void TestGroup::testFindEntry()
     QScopedPointer<Database> db(new Database());
 
     auto entry1 = new Entry();
-    entry1->setTitle(QString("entry1"));
+    entry1->setTitle(QStringLiteral("entry1"));
     entry1->setGroup(db->rootGroup());
     entry1->setUuid(QUuid::createUuid());
 
@@ -486,7 +486,7 @@ void TestGroup::testFindEntry()
 
     auto entry2 = new Entry();
 
-    entry2->setTitle(QString("entry2"));
+    entry2->setTitle(QStringLiteral("entry2"));
     entry2->setGroup(group1);
     entry2->setUuid(QUuid::createUuid());
 
@@ -496,46 +496,46 @@ void TestGroup::testFindEntry()
 
     entry = db->rootGroup()->findEntryByUuid(entry1->uuid());
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry1"));
+    QCOMPARE(entry->title(), QStringLiteral("entry1"));
 
-    entry = db->rootGroup()->findEntryByPath(QString("entry1"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("entry1"));
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry1"));
+    QCOMPARE(entry->title(), QStringLiteral("entry1"));
 
     // We also can find the entry with the leading slash.
-    entry = db->rootGroup()->findEntryByPath(QString("/entry1"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("/entry1"));
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry1"));
+    QCOMPARE(entry->title(), QStringLiteral("entry1"));
 
     // But two slashes should not be accepted.
-    entry = db->rootGroup()->findEntryByPath(QString("//entry1"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("//entry1"));
     QVERIFY(!entry);
 
     entry = db->rootGroup()->findEntryByUuid(entry2->uuid());
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry2"));
+    QCOMPARE(entry->title(), QStringLiteral("entry2"));
 
-    entry = db->rootGroup()->findEntryByPath(QString("group1/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("group1/entry2"));
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry2"));
+    QCOMPARE(entry->title(), QStringLiteral("entry2"));
 
-    entry = db->rootGroup()->findEntryByPath(QString("/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("/entry2"));
     QVERIFY(!entry);
 
     // We also can find the entry with the leading slash.
-    entry = db->rootGroup()->findEntryByPath(QString("/group1/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("/group1/entry2"));
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry2"));
+    QCOMPARE(entry->title(), QStringLiteral("entry2"));
 
     // Should also find the entry only by title.
-    entry = db->rootGroup()->findEntryByPath(QString("entry2"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("entry2"));
     QVERIFY(entry);
-    QCOMPARE(entry->title(), QString("entry2"));
+    QCOMPARE(entry->title(), QStringLiteral("entry2"));
 
-    entry = db->rootGroup()->findEntryByPath(QString("invalid/path/to/entry2"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("invalid/path/to/entry2"));
     QVERIFY(!entry);
 
-    entry = db->rootGroup()->findEntryByPath(QString("entry27"));
+    entry = db->rootGroup()->findEntryByPath(QStringLiteral("entry27"));
     QVERIFY(!entry);
 
     // A valid UUID that does not exist in this database.
@@ -621,25 +621,25 @@ void TestGroup::testPrint()
     QScopedPointer<Database> db(new Database());
 
     QString output = db->rootGroup()->print();
-    QCOMPARE(output, QString("[empty]\n"));
+    QCOMPARE(output, QStringLiteral("[empty]\n"));
 
     output = db->rootGroup()->print(true);
-    QCOMPARE(output, QString("[empty]\n"));
+    QCOMPARE(output, QStringLiteral("[empty]\n"));
 
     auto entry1 = new Entry();
-    entry1->setTitle(QString("entry1"));
+    entry1->setTitle(QStringLiteral("entry1"));
     entry1->setGroup(db->rootGroup());
     entry1->setUuid(QUuid::createUuid());
 
     output = db->rootGroup()->print();
-    QCOMPARE(output, QString("entry1\n"));
+    QCOMPARE(output, QStringLiteral("entry1\n"));
 
     auto group1 = new Group();
     group1->setName("group1");
     group1->setParent(db->rootGroup());
 
     auto entry2 = new Entry();
-    entry2->setTitle(QString("entry2"));
+    entry2->setTitle(QStringLiteral("entry2"));
     entry2->setGroup(group1);
     entry2->setUuid(QUuid::createUuid());
 
@@ -652,41 +652,41 @@ void TestGroup::testPrint()
     subGroup->setParent(group2);
 
     auto entry3 = new Entry();
-    entry3->setTitle(QString("entry3"));
+    entry3->setTitle(QStringLiteral("entry3"));
     entry3->setGroup(subGroup);
     entry3->setUuid(QUuid::createUuid());
 
     output = db->rootGroup()->print();
-    QVERIFY(output.contains(QString("entry1\n")));
-    QVERIFY(output.contains(QString("group1/\n")));
-    QVERIFY(!output.contains(QString("  entry2\n")));
-    QVERIFY(output.contains(QString("group2/\n")));
-    QVERIFY(!output.contains(QString("  subgroup\n")));
+    QVERIFY(output.contains(QStringLiteral("entry1\n")));
+    QVERIFY(output.contains(QStringLiteral("group1/\n")));
+    QVERIFY(!output.contains(QStringLiteral("  entry2\n")));
+    QVERIFY(output.contains(QStringLiteral("group2/\n")));
+    QVERIFY(!output.contains(QStringLiteral("  subgroup\n")));
 
     output = db->rootGroup()->print(true);
-    QVERIFY(output.contains(QString("entry1\n")));
-    QVERIFY(output.contains(QString("group1/\n")));
-    QVERIFY(output.contains(QString("  entry2\n")));
-    QVERIFY(output.contains(QString("group2/\n")));
-    QVERIFY(output.contains(QString("  subgroup/\n")));
-    QVERIFY(output.contains(QString("    entry3\n")));
+    QVERIFY(output.contains(QStringLiteral("entry1\n")));
+    QVERIFY(output.contains(QStringLiteral("group1/\n")));
+    QVERIFY(output.contains(QStringLiteral("  entry2\n")));
+    QVERIFY(output.contains(QStringLiteral("group2/\n")));
+    QVERIFY(output.contains(QStringLiteral("  subgroup/\n")));
+    QVERIFY(output.contains(QStringLiteral("    entry3\n")));
 
     output = db->rootGroup()->print(true, true);
-    QVERIFY(output.contains(QString("entry1\n")));
-    QVERIFY(output.contains(QString("group1/\n")));
-    QVERIFY(output.contains(QString("group1/entry2\n")));
-    QVERIFY(output.contains(QString("group2/\n")));
-    QVERIFY(output.contains(QString("group2/subgroup/\n")));
-    QVERIFY(output.contains(QString("group2/subgroup/entry3\n")));
+    QVERIFY(output.contains(QStringLiteral("entry1\n")));
+    QVERIFY(output.contains(QStringLiteral("group1/\n")));
+    QVERIFY(output.contains(QStringLiteral("group1/entry2\n")));
+    QVERIFY(output.contains(QStringLiteral("group2/\n")));
+    QVERIFY(output.contains(QStringLiteral("group2/subgroup/\n")));
+    QVERIFY(output.contains(QStringLiteral("group2/subgroup/entry3\n")));
 
     output = group1->print();
-    QVERIFY(!output.contains(QString("group1/\n")));
-    QVERIFY(output.contains(QString("entry2\n")));
+    QVERIFY(!output.contains(QStringLiteral("group1/\n")));
+    QVERIFY(output.contains(QStringLiteral("entry2\n")));
 
     output = group2->print(true, true);
-    QVERIFY(!output.contains(QString("group2/\n")));
-    QVERIFY(output.contains(QString("subgroup/\n")));
-    QVERIFY(output.contains(QString("subgroup/entry3\n")));
+    QVERIFY(!output.contains(QStringLiteral("group2/\n")));
+    QVERIFY(output.contains(QStringLiteral("subgroup/\n")));
+    QVERIFY(output.contains(QStringLiteral("subgroup/entry3\n")));
 }
 
 void TestGroup::testAddEntryWithPath()
@@ -883,27 +883,27 @@ void TestGroup::testChildrenSort()
     parent->sortChildrenRecursively();
     QList<Group*> children = parent->children();
     QCOMPARE(children.size(), 10);
-    QCOMPARE(children[0]->name(), QString("045"));
-    QCOMPARE(children[1]->name(), QString("04test"));
-    QCOMPARE(children[2]->name(), QString("60"));
-    QCOMPARE(children[3]->name(), QString("A"));
-    QCOMPARE(children[4]->name(), QString("B"));
-    QCOMPARE(children[5]->name(), QString("e"));
-    QCOMPARE(children[6]->name(), QString("i"));
-    QCOMPARE(children[7]->name(), QString("Test12"));
-    QCOMPARE(children[8]->name(), QString("Test999"));
-    QCOMPARE(children[9]->name(), QString("z"));
+    QCOMPARE(children[0]->name(), QStringLiteral("045"));
+    QCOMPARE(children[1]->name(), QStringLiteral("04test"));
+    QCOMPARE(children[2]->name(), QStringLiteral("60"));
+    QCOMPARE(children[3]->name(), QStringLiteral("A"));
+    QCOMPARE(children[4]->name(), QStringLiteral("B"));
+    QCOMPARE(children[5]->name(), QStringLiteral("e"));
+    QCOMPARE(children[6]->name(), QStringLiteral("i"));
+    QCOMPARE(children[7]->name(), QStringLiteral("Test12"));
+    QCOMPARE(children[8]->name(), QStringLiteral("Test999"));
+    QCOMPARE(children[9]->name(), QStringLiteral("z"));
     children = subParent->children();
     QCOMPARE(children.size(), 9);
-    QCOMPARE(children[0]->name(), QString("sub_000"));
-    QCOMPARE(children[1]->name(), QString("sub_010"));
-    QCOMPARE(children[2]->name(), QString("sub_45p"));
-    QCOMPARE(children[3]->name(), QString("sub_6p"));
-    QCOMPARE(children[4]->name(), QString("sub_M"));
-    QCOMPARE(children[5]->name(), QString("sub_p"));
-    QCOMPARE(children[6]->name(), QString("sub_t0"));
-    QCOMPARE(children[7]->name(), QString("sub_tt"));
-    QCOMPARE(children[8]->name(), QString("sub_xte"));
+    QCOMPARE(children[0]->name(), QStringLiteral("sub_000"));
+    QCOMPARE(children[1]->name(), QStringLiteral("sub_010"));
+    QCOMPARE(children[2]->name(), QStringLiteral("sub_45p"));
+    QCOMPARE(children[3]->name(), QStringLiteral("sub_6p"));
+    QCOMPARE(children[4]->name(), QStringLiteral("sub_M"));
+    QCOMPARE(children[5]->name(), QStringLiteral("sub_p"));
+    QCOMPARE(children[6]->name(), QStringLiteral("sub_t0"));
+    QCOMPARE(children[7]->name(), QStringLiteral("sub_tt"));
+    QCOMPARE(children[8]->name(), QStringLiteral("sub_xte"));
     delete parent;
 
     parent = createTestGroupWithUnorderedChildren();
@@ -911,27 +911,27 @@ void TestGroup::testChildrenSort()
     parent->sortChildrenRecursively(true);
     children = parent->children();
     QCOMPARE(children.size(), 10);
-    QCOMPARE(children[0]->name(), QString("z"));
-    QCOMPARE(children[1]->name(), QString("Test999"));
-    QCOMPARE(children[2]->name(), QString("Test12"));
-    QCOMPARE(children[3]->name(), QString("i"));
-    QCOMPARE(children[4]->name(), QString("e"));
-    QCOMPARE(children[5]->name(), QString("B"));
-    QCOMPARE(children[6]->name(), QString("A"));
-    QCOMPARE(children[7]->name(), QString("60"));
-    QCOMPARE(children[8]->name(), QString("04test"));
-    QCOMPARE(children[9]->name(), QString("045"));
+    QCOMPARE(children[0]->name(), QStringLiteral("z"));
+    QCOMPARE(children[1]->name(), QStringLiteral("Test999"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Test12"));
+    QCOMPARE(children[3]->name(), QStringLiteral("i"));
+    QCOMPARE(children[4]->name(), QStringLiteral("e"));
+    QCOMPARE(children[5]->name(), QStringLiteral("B"));
+    QCOMPARE(children[6]->name(), QStringLiteral("A"));
+    QCOMPARE(children[7]->name(), QStringLiteral("60"));
+    QCOMPARE(children[8]->name(), QStringLiteral("04test"));
+    QCOMPARE(children[9]->name(), QStringLiteral("045"));
     children = subParent->children();
     QCOMPARE(children.size(), 9);
-    QCOMPARE(children[0]->name(), QString("sub_xte"));
-    QCOMPARE(children[1]->name(), QString("sub_tt"));
-    QCOMPARE(children[2]->name(), QString("sub_t0"));
-    QCOMPARE(children[3]->name(), QString("sub_p"));
-    QCOMPARE(children[4]->name(), QString("sub_M"));
-    QCOMPARE(children[5]->name(), QString("sub_6p"));
-    QCOMPARE(children[6]->name(), QString("sub_45p"));
-    QCOMPARE(children[7]->name(), QString("sub_010"));
-    QCOMPARE(children[8]->name(), QString("sub_000"));
+    QCOMPARE(children[0]->name(), QStringLiteral("sub_xte"));
+    QCOMPARE(children[1]->name(), QStringLiteral("sub_tt"));
+    QCOMPARE(children[2]->name(), QStringLiteral("sub_t0"));
+    QCOMPARE(children[3]->name(), QStringLiteral("sub_p"));
+    QCOMPARE(children[4]->name(), QStringLiteral("sub_M"));
+    QCOMPARE(children[5]->name(), QStringLiteral("sub_6p"));
+    QCOMPARE(children[6]->name(), QStringLiteral("sub_45p"));
+    QCOMPARE(children[7]->name(), QStringLiteral("sub_010"));
+    QCOMPARE(children[8]->name(), QStringLiteral("sub_000"));
     delete parent;
 
     parent = createTestGroupWithUnorderedChildren();
@@ -939,27 +939,27 @@ void TestGroup::testChildrenSort()
     subParent->sortChildrenRecursively();
     children = parent->children();
     QCOMPARE(children.size(), 10);
-    QCOMPARE(children[0]->name(), QString("B"));
-    QCOMPARE(children[1]->name(), QString("e"));
-    QCOMPARE(children[2]->name(), QString("Test999"));
-    QCOMPARE(children[3]->name(), QString("A"));
-    QCOMPARE(children[4]->name(), QString("z"));
-    QCOMPARE(children[5]->name(), QString("045"));
-    QCOMPARE(children[6]->name(), QString("60"));
-    QCOMPARE(children[7]->name(), QString("04test"));
-    QCOMPARE(children[8]->name(), QString("Test12"));
-    QCOMPARE(children[9]->name(), QString("i"));
+    QCOMPARE(children[0]->name(), QStringLiteral("B"));
+    QCOMPARE(children[1]->name(), QStringLiteral("e"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Test999"));
+    QCOMPARE(children[3]->name(), QStringLiteral("A"));
+    QCOMPARE(children[4]->name(), QStringLiteral("z"));
+    QCOMPARE(children[5]->name(), QStringLiteral("045"));
+    QCOMPARE(children[6]->name(), QStringLiteral("60"));
+    QCOMPARE(children[7]->name(), QStringLiteral("04test"));
+    QCOMPARE(children[8]->name(), QStringLiteral("Test12"));
+    QCOMPARE(children[9]->name(), QStringLiteral("i"));
     children = subParent->children();
     QCOMPARE(children.size(), 9);
-    QCOMPARE(children[0]->name(), QString("sub_000"));
-    QCOMPARE(children[1]->name(), QString("sub_010"));
-    QCOMPARE(children[2]->name(), QString("sub_45p"));
-    QCOMPARE(children[3]->name(), QString("sub_6p"));
-    QCOMPARE(children[4]->name(), QString("sub_M"));
-    QCOMPARE(children[5]->name(), QString("sub_p"));
-    QCOMPARE(children[6]->name(), QString("sub_t0"));
-    QCOMPARE(children[7]->name(), QString("sub_tt"));
-    QCOMPARE(children[8]->name(), QString("sub_xte"));
+    QCOMPARE(children[0]->name(), QStringLiteral("sub_000"));
+    QCOMPARE(children[1]->name(), QStringLiteral("sub_010"));
+    QCOMPARE(children[2]->name(), QStringLiteral("sub_45p"));
+    QCOMPARE(children[3]->name(), QStringLiteral("sub_6p"));
+    QCOMPARE(children[4]->name(), QStringLiteral("sub_M"));
+    QCOMPARE(children[5]->name(), QStringLiteral("sub_p"));
+    QCOMPARE(children[6]->name(), QStringLiteral("sub_t0"));
+    QCOMPARE(children[7]->name(), QStringLiteral("sub_tt"));
+    QCOMPARE(children[8]->name(), QStringLiteral("sub_xte"));
     delete parent;
 
     parent = createTestGroupWithUnorderedChildren();
@@ -967,27 +967,27 @@ void TestGroup::testChildrenSort()
     subParent->sortChildrenRecursively(true);
     children = parent->children();
     QCOMPARE(children.size(), 10);
-    QCOMPARE(children[0]->name(), QString("B"));
-    QCOMPARE(children[1]->name(), QString("e"));
-    QCOMPARE(children[2]->name(), QString("Test999"));
-    QCOMPARE(children[3]->name(), QString("A"));
-    QCOMPARE(children[4]->name(), QString("z"));
-    QCOMPARE(children[5]->name(), QString("045"));
-    QCOMPARE(children[6]->name(), QString("60"));
-    QCOMPARE(children[7]->name(), QString("04test"));
-    QCOMPARE(children[8]->name(), QString("Test12"));
-    QCOMPARE(children[9]->name(), QString("i"));
+    QCOMPARE(children[0]->name(), QStringLiteral("B"));
+    QCOMPARE(children[1]->name(), QStringLiteral("e"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Test999"));
+    QCOMPARE(children[3]->name(), QStringLiteral("A"));
+    QCOMPARE(children[4]->name(), QStringLiteral("z"));
+    QCOMPARE(children[5]->name(), QStringLiteral("045"));
+    QCOMPARE(children[6]->name(), QStringLiteral("60"));
+    QCOMPARE(children[7]->name(), QStringLiteral("04test"));
+    QCOMPARE(children[8]->name(), QStringLiteral("Test12"));
+    QCOMPARE(children[9]->name(), QStringLiteral("i"));
     children = subParent->children();
     QCOMPARE(children.size(), 9);
-    QCOMPARE(children[0]->name(), QString("sub_xte"));
-    QCOMPARE(children[1]->name(), QString("sub_tt"));
-    QCOMPARE(children[2]->name(), QString("sub_t0"));
-    QCOMPARE(children[3]->name(), QString("sub_p"));
-    QCOMPARE(children[4]->name(), QString("sub_M"));
-    QCOMPARE(children[5]->name(), QString("sub_6p"));
-    QCOMPARE(children[6]->name(), QString("sub_45p"));
-    QCOMPARE(children[7]->name(), QString("sub_010"));
-    QCOMPARE(children[8]->name(), QString("sub_000"));
+    QCOMPARE(children[0]->name(), QStringLiteral("sub_xte"));
+    QCOMPARE(children[1]->name(), QStringLiteral("sub_tt"));
+    QCOMPARE(children[2]->name(), QStringLiteral("sub_t0"));
+    QCOMPARE(children[3]->name(), QStringLiteral("sub_p"));
+    QCOMPARE(children[4]->name(), QStringLiteral("sub_M"));
+    QCOMPARE(children[5]->name(), QStringLiteral("sub_6p"));
+    QCOMPARE(children[6]->name(), QStringLiteral("sub_45p"));
+    QCOMPARE(children[7]->name(), QStringLiteral("sub_010"));
+    QCOMPARE(children[8]->name(), QStringLiteral("sub_000"));
     delete parent;
 }
 

--- a/tests/TestGroupModel.cpp
+++ b/tests/TestGroupModel.cpp
@@ -71,17 +71,17 @@ void TestGroupModel::test()
     QPersistentModelIndex index12 = model->index(1, 0, index1);
     QModelIndex index121 = model->index(0, 0, index12);
 
-    QCOMPARE(model->data(indexRoot).toString(), QString("groupRoot"));
-    QCOMPARE(model->data(index1).toString(), QString("group1"));
-    QCOMPARE(model->data(index11).toString(), QString("group11"));
-    QCOMPARE(model->data(index12).toString(), QString("group12"));
-    QCOMPARE(model->data(index121).toString(), QString("group121"));
+    QCOMPARE(model->data(indexRoot).toString(), QStringLiteral("groupRoot"));
+    QCOMPARE(model->data(index1).toString(), QStringLiteral("group1"));
+    QCOMPARE(model->data(index11).toString(), QStringLiteral("group11"));
+    QCOMPARE(model->data(index12).toString(), QStringLiteral("group12"));
+    QCOMPARE(model->data(index121).toString(), QStringLiteral("group121"));
 
     QSignalSpy spy1(model, SIGNAL(dataChanged(QModelIndex, QModelIndex)));
     group11->setName("test");
     group121->setIcon(4);
     QCOMPARE(spy1.count(), 2);
-    QCOMPARE(model->data(index11).toString(), QString("test"));
+    QCOMPARE(model->data(index11).toString(), QStringLiteral("test"));
 
     QSignalSpy spyAboutToAdd(model, SIGNAL(rowsAboutToBeInserted(QModelIndex, int, int)));
     QSignalSpy spyAdded(model, SIGNAL(rowsInserted(QModelIndex, int, int)));
@@ -101,7 +101,7 @@ void TestGroupModel::test()
     QCOMPARE(spyRemoved.count(), 0);
     QCOMPARE(spyAboutToMove.count(), 0);
     QCOMPARE(spyMoved.count(), 0);
-    QCOMPARE(model->data(index2).toString(), QString("group2"));
+    QCOMPARE(model->data(index2).toString(), QStringLiteral("group2"));
 
     group12->setParent(group1, 0);
     QCOMPARE(spyAboutToAdd.count(), 1);
@@ -110,7 +110,7 @@ void TestGroupModel::test()
     QCOMPARE(spyRemoved.count(), 0);
     QCOMPARE(spyAboutToMove.count(), 1);
     QCOMPARE(spyMoved.count(), 1);
-    QCOMPARE(model->data(index12).toString(), QString("group12"));
+    QCOMPARE(model->data(index12).toString(), QStringLiteral("group12"));
 
     group12->setParent(group1, 1);
     QCOMPARE(spyAboutToAdd.count(), 1);
@@ -119,7 +119,7 @@ void TestGroupModel::test()
     QCOMPARE(spyRemoved.count(), 0);
     QCOMPARE(spyAboutToMove.count(), 2);
     QCOMPARE(spyMoved.count(), 2);
-    QCOMPARE(model->data(index12).toString(), QString("group12"));
+    QCOMPARE(model->data(index12).toString(), QStringLiteral("group12"));
 
     group12->setParent(group2);
     QCOMPARE(spyAboutToAdd.count(), 1);
@@ -129,8 +129,8 @@ void TestGroupModel::test()
     QCOMPARE(spyAboutToMove.count(), 3);
     QCOMPARE(spyMoved.count(), 3);
     QVERIFY(index12.isValid());
-    QCOMPARE(model->data(index12).toString(), QString("group12"));
-    QCOMPARE(model->data(index12.model()->index(0, 0, index12)).toString(), QString("group121"));
+    QCOMPARE(model->data(index12).toString(), QStringLiteral("group12"));
+    QCOMPARE(model->data(index12.model()->index(0, 0, index12)).toString(), QStringLiteral("group121"));
 
     delete group12;
     QCOMPARE(spyAboutToAdd.count(), 1);

--- a/tests/TestHashedBlockStream.cpp
+++ b/tests/TestHashedBlockStream.cpp
@@ -99,5 +99,5 @@ void TestHashedBlockStream::testWriteFailure()
     QCOMPARE(writer.write(input.left(900)), qint64(900));
     writer.write(input.left(900));
     QVERIFY(!writer.reset());
-    QCOMPARE(writer.errorString(), QString("FAILDEVICE"));
+    QCOMPARE(writer.errorString(), QStringLiteral("FAILDEVICE"));
 }

--- a/tests/TestImports.cpp
+++ b/tests/TestImports.cpp
@@ -67,13 +67,13 @@ void TestImports::testOPUX()
     entry = db->rootGroup()->findEntryByPath("/Personal/KeePassXC Logo");
     auto attachments = entry->attachments();
     QCOMPARE(attachments->keys().count(), 1);
-    QCOMPARE(attachments->keys()[0], QString("keepassxc.png"));
+    QCOMPARE(attachments->keys()[0], QStringLiteral("keepassxc.png"));
 
     // Confirm advanced attributes
     // NOTE: 1PUX does not support an explicit expiration field
     entry = db->rootGroup()->findEntryByPath("/Personal/Credit Card");
     QVERIFY(entry);
-    auto tmpl = QString("Credit Card Fields_%1");
+    auto tmpl = QStringLiteral("Credit Card Fields_%1");
     auto attr = entry->attributes();
     QCOMPARE(attr->value(tmpl.arg("cardholder name")), QStringLiteral("KeePassXC"));
     QCOMPARE(attr->value(tmpl.arg("expiry date")), QStringLiteral("202206"));

--- a/tests/TestKdbx2.cpp
+++ b/tests/TestKdbx2.cpp
@@ -41,7 +41,7 @@ void TestKdbx2::initTestCase()
 void TestKdbx2::verifyKdbx2Db(QSharedPointer<Database> db)
 {
     QVERIFY(db);
-    QCOMPARE(db->rootGroup()->name(), QString("Format200"));
+    QCOMPARE(db->rootGroup()->name(), QStringLiteral("Format200"));
     QVERIFY(!db->metadata()->protectTitle());
     QVERIFY(db->metadata()->protectUsername());
     QVERIFY(!db->metadata()->protectPassword());
@@ -51,8 +51,8 @@ void TestKdbx2::verifyKdbx2Db(QSharedPointer<Database> db)
     QCOMPARE(db->rootGroup()->entries().size(), 1);
     auto entry = db->rootGroup()->entries().at(0);
 
-    QCOMPARE(entry->title(), QString("Sample Entry"));
-    QCOMPARE(entry->username(), QString("User Name"));
+    QCOMPARE(entry->title(), QStringLiteral("Sample Entry"));
+    QCOMPARE(entry->username(), QStringLiteral("User Name"));
     QCOMPARE(entry->attachments()->keys().size(), 2);
     QCOMPARE(entry->attachments()->value("myattach.txt"), QByteArray("abcdefghijk"));
     QCOMPARE(entry->attachments()->value("test.txt"), QByteArray("this is a test"));
@@ -65,7 +65,7 @@ void TestKdbx2::verifyKdbx2Db(QSharedPointer<Database> db)
 
 void TestKdbx2::testFormat200()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     auto db = QSharedPointer<Database>::create();
@@ -79,7 +79,7 @@ void TestKdbx2::testFormat200()
 
 void TestKdbx2::testFormat200Upgrade()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Format200.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     auto db = QSharedPointer<Database>::create();
@@ -97,7 +97,7 @@ void TestKdbx2::testFormat200Upgrade()
     KeePass2Writer writer;
     QVERIFY(writer.writeDatabase(&buffer, db.data()));
     if (writer.hasError()) {
-        QFAIL(qPrintable(QString("Error while writing database: %1").arg(writer.errorString())));
+        QFAIL(qPrintable(QStringLiteral("Error while writing database: %1").arg(writer.errorString())));
     }
 
     // read buffer back
@@ -105,7 +105,7 @@ void TestKdbx2::testFormat200Upgrade()
     auto targetDb = QSharedPointer<Database>::create();
     QVERIFY(reader.readDatabase(&buffer, key, targetDb.data()));
     if (reader.hasError()) {
-        QFAIL(qPrintable(QString("Error while reading database: %1").arg(reader.errorString())));
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: %1").arg(reader.errorString())));
     }
 
     // database should now be upgraded to KDBX 3 without data loss

--- a/tests/TestKdbx3.cpp
+++ b/tests/TestKdbx3.cpp
@@ -91,7 +91,7 @@ void TestKdbx3::writeKdbx(QIODevice* device, Database* db, bool& hasError, QStri
 
 void TestKdbx3::testFormat300()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format300.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Format300.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("a"));
     KeePass2Reader reader;
@@ -101,13 +101,13 @@ void TestKdbx3::testFormat300()
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
 
-    QCOMPARE(db->rootGroup()->name(), QString("Format300"));
-    QCOMPARE(db->metadata()->name(), QString("Test Database Format 0x00030000"));
+    QCOMPARE(db->rootGroup()->name(), QStringLiteral("Format300"));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("Test Database Format 0x00030000"));
 }
 
 void TestKdbx3::testNonAscii()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/NonAscii.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NonAscii.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(QString::fromUtf8("\xce\x94\xc3\xb6\xd8\xb6")));
     KeePass2Reader reader;
@@ -115,13 +115,13 @@ void TestKdbx3::testNonAscii()
     QVERIFY(db->open(filename, key, nullptr));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
-    QCOMPARE(db->metadata()->name(), QString("NonAsciiTest"));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("NonAsciiTest"));
     QCOMPARE(db->compressionAlgorithm(), Database::CompressionNone);
 }
 
 void TestKdbx3::testCompressed()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Compressed.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Compressed.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     KeePass2Reader reader;
@@ -129,13 +129,13 @@ void TestKdbx3::testCompressed()
     QVERIFY(db->open(filename, key, nullptr));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
-    QCOMPARE(db->metadata()->name(), QString("Compressed"));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("Compressed"));
     QCOMPARE(db->compressionAlgorithm(), Database::CompressionGZip);
 }
 
 void TestKdbx3::testProtectedStrings()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/ProtectedStrings.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/ProtectedStrings.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("masterpw"));
     KeePass2Reader reader;
@@ -143,15 +143,15 @@ void TestKdbx3::testProtectedStrings()
     QVERIFY(db->open(filename, key, nullptr));
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
-    QCOMPARE(db->metadata()->name(), QString("Protected Strings Test"));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("Protected Strings Test"));
 
     Entry* entry = db->rootGroup()->entries().at(0);
 
-    QCOMPARE(entry->title(), QString("Sample Entry"));
-    QCOMPARE(entry->username(), QString("Protected User Name"));
-    QCOMPARE(entry->password(), QString("ProtectedPassword"));
-    QCOMPARE(entry->attributes()->value("TestProtected"), QString("ABC"));
-    QCOMPARE(entry->attributes()->value("TestUnprotected"), QString("DEF"));
+    QCOMPARE(entry->title(), QStringLiteral("Sample Entry"));
+    QCOMPARE(entry->username(), QStringLiteral("Protected User Name"));
+    QCOMPARE(entry->password(), QStringLiteral("ProtectedPassword"));
+    QCOMPARE(entry->attributes()->value("TestProtected"), QStringLiteral("ABC"));
+    QCOMPARE(entry->attributes()->value("TestUnprotected"), QStringLiteral("DEF"));
 
     QVERIFY(db->metadata()->protectPassword());
     QVERIFY(entry->attributes()->isProtected("TestProtected"));
@@ -163,7 +163,7 @@ void TestKdbx3::testBrokenHeaderHash()
     // The protected stream key has been modified in the header.
     // Make sure the database won't open.
 
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/BrokenHeaderHash.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/BrokenHeaderHash.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create(""));
     auto db = QSharedPointer<Database>::create();

--- a/tests/TestKdbx4.cpp
+++ b/tests/TestKdbx4.cpp
@@ -131,7 +131,7 @@ void TestKdbx4Format::cleanup()
 
 void TestKdbx4Format::testFormat400()
 {
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/Format400.kdbx");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/Format400.kdbx");
     auto key = QSharedPointer<CompositeKey>::create();
     key->addKey(QSharedPointer<PasswordKey>::create("t"));
     KeePass2Reader reader;
@@ -141,15 +141,15 @@ void TestKdbx4Format::testFormat400()
     QVERIFY(db.data());
     QVERIFY(!reader.hasError());
 
-    QCOMPARE(db->rootGroup()->name(), QString("Format400"));
-    QCOMPARE(db->metadata()->name(), QString("Format400"));
+    QCOMPARE(db->rootGroup()->name(), QStringLiteral("Format400"));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("Format400"));
     QCOMPARE(db->rootGroup()->entries().size(), 1);
     auto entry = db->rootGroup()->entries().at(0);
 
-    QCOMPARE(entry->title(), QString("Format400"));
-    QCOMPARE(entry->username(), QString("Format400"));
+    QCOMPARE(entry->title(), QStringLiteral("Format400"));
+    QCOMPARE(entry->username(), QStringLiteral("Format400"));
     QCOMPARE(entry->attributes()->keys().size(), 6);
-    QCOMPARE(entry->attributes()->value("Format400"), QString("Format400"));
+    QCOMPARE(entry->attributes()->value("Format400"), QStringLiteral("Format400"));
     QCOMPARE(entry->attachments()->keys().size(), 1);
     QCOMPARE(entry->attachments()->value("Format400"), QByteArray("Format400\n"));
 }
@@ -188,7 +188,7 @@ void TestKdbx4Format::testFormat400Upgrade()
     KeePass2Writer writer;
     writer.writeDatabase(&buffer, sourceDb.data());
     if (writer.hasError()) {
-        QFAIL(qPrintable(QString("Error while writing database: %1").arg(writer.errorString())));
+        QFAIL(qPrintable(QStringLiteral("Error while writing database: %1").arg(writer.errorString())));
     }
 
     // read buffer back
@@ -197,7 +197,7 @@ void TestKdbx4Format::testFormat400Upgrade()
     auto targetDb = QSharedPointer<Database>::create();
     reader.readDatabase(&buffer, key, targetDb.data());
     if (reader.hasError()) {
-        QFAIL(qPrintable(QString("Error while reading database: %1").arg(reader.errorString())));
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: %1").arg(reader.errorString())));
     }
 
     QVERIFY(targetDb->rootGroup());
@@ -373,7 +373,7 @@ void TestKdbx4Format::testUpgradeMasterKeyIntegrity()
         entry->setUuid(QUuid::createUuid());
         entry->customData()->set("abc", "def");
     } else {
-        QFAIL(qPrintable(QString("Unknown action: %s").arg(upgradeAction)));
+        QFAIL(qPrintable(QStringLiteral("Unknown action: %s").arg(upgradeAction)));
     }
 
     QBuffer buffer;
@@ -407,18 +407,18 @@ void TestKdbx4Format::testUpgradeMasterKeyIntegrity_data()
     QTest::addColumn<QString>("upgradeAction");
     QTest::addColumn<quint32>("expectedVersion");
 
-    QTest::newRow("Upgrade: none") << QString("none") << KeePass2::FILE_VERSION_3_1;
-    QTest::newRow("Upgrade: none (meta-customdata)") << QString("meta-customdata") << KeePass2::FILE_VERSION_3_1;
-    QTest::newRow("Upgrade: none (explicit kdf-aes-kdbx3)") << QString("kdf-aes-kdbx3") << KeePass2::FILE_VERSION_3_1;
-    QTest::newRow("Upgrade (explicit): kdf-argon2") << QString("kdf-argon2") << KeePass2::FILE_VERSION_4;
-    QTest::newRow("Upgrade (explicit): kdf-aes-kdbx4") << QString("kdf-aes-kdbx4") << KeePass2::FILE_VERSION_4;
-    QTest::newRow("Upgrade (implicit): public-customdata") << QString("public-customdata") << KeePass2::FILE_VERSION_4;
+    QTest::newRow("Upgrade: none") << QStringLiteral("none") << KeePass2::FILE_VERSION_3_1;
+    QTest::newRow("Upgrade: none (meta-customdata)") << QStringLiteral("meta-customdata") << KeePass2::FILE_VERSION_3_1;
+    QTest::newRow("Upgrade: none (explicit kdf-aes-kdbx3)") << QStringLiteral("kdf-aes-kdbx3") << KeePass2::FILE_VERSION_3_1;
+    QTest::newRow("Upgrade (explicit): kdf-argon2") << QStringLiteral("kdf-argon2") << KeePass2::FILE_VERSION_4;
+    QTest::newRow("Upgrade (explicit): kdf-aes-kdbx4") << QStringLiteral("kdf-aes-kdbx4") << KeePass2::FILE_VERSION_4;
+    QTest::newRow("Upgrade (implicit): public-customdata") << QStringLiteral("public-customdata") << KeePass2::FILE_VERSION_4;
     QTest::newRow("Upgrade (implicit): rootgroup-customdata")
-        << QString("rootgroup-customdata") << KeePass2::FILE_VERSION_4;
-    QTest::newRow("Upgrade (implicit): group-customdata") << QString("group-customdata") << KeePass2::FILE_VERSION_4;
+        << QStringLiteral("rootgroup-customdata") << KeePass2::FILE_VERSION_4;
+    QTest::newRow("Upgrade (implicit): group-customdata") << QStringLiteral("group-customdata") << KeePass2::FILE_VERSION_4;
     QTest::newRow("Upgrade (implicit): rootentry-customdata")
-        << QString("rootentry-customdata") << KeePass2::FILE_VERSION_4;
-    QTest::newRow("Upgrade (implicit): entry-customdata") << QString("entry-customdata") << KeePass2::FILE_VERSION_4;
+        << QStringLiteral("rootentry-customdata") << KeePass2::FILE_VERSION_4;
+    QTest::newRow("Upgrade (implicit): entry-customdata") << QStringLiteral("entry-customdata") << KeePass2::FILE_VERSION_4;
 }
 
 void TestKdbx4Format::testAttachmentIndexStability()

--- a/tests/TestKeePass1Reader.cpp
+++ b/tests/TestKeePass1Reader.cpp
@@ -36,7 +36,7 @@ void TestKeePass1Reader::initTestCase()
 {
     QVERIFY(Crypto::init());
 
-    QString filename = QString(KEEPASSX_TEST_DATA_DIR).append("/basic.kdb");
+    QString filename = QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/basic.kdb");
 
     KeePass1Reader reader;
     m_db = reader.readDatabase(filename, "masterpw", nullptr);
@@ -52,53 +52,53 @@ void TestKeePass1Reader::testBasic()
 
     Group* group1 = m_db->rootGroup()->children().at(0);
     QVERIFY(!group1->uuid().isNull());
-    QCOMPARE(group1->name(), QString("Internet"));
+    QCOMPARE(group1->name(), QStringLiteral("Internet"));
     QCOMPARE(group1->children().size(), 2);
     QCOMPARE(group1->entries().size(), 2);
     QCOMPARE(group1->iconNumber(), 1);
 
     Entry* entry11 = group1->entries().at(0);
     QVERIFY(!entry11->uuid().isNull());
-    QCOMPARE(entry11->title(), QString("Test entry"));
+    QCOMPARE(entry11->title(), QStringLiteral("Test entry"));
     QCOMPARE(entry11->iconNumber(), 1);
-    QCOMPARE(entry11->username(), QString("I"));
-    QCOMPARE(entry11->url(), QString("http://example.com/"));
-    QCOMPARE(entry11->password(), QString("secretpassword"));
-    QCOMPARE(entry11->notes(), QString("Lorem ipsum\ndolor sit amet"));
+    QCOMPARE(entry11->username(), QStringLiteral("I"));
+    QCOMPARE(entry11->url(), QStringLiteral("http://example.com/"));
+    QCOMPARE(entry11->password(), QStringLiteral("secretpassword"));
+    QCOMPARE(entry11->notes(), QStringLiteral("Lorem ipsum\ndolor sit amet"));
     QVERIFY(entry11->timeInfo().expires());
     QCOMPARE(entry11->timeInfo().expiryTime(), genDT(2012, 5, 9, 10, 32));
     QCOMPARE(entry11->attachments()->keys().size(), 1);
-    QCOMPARE(entry11->attachments()->keys().at(0), QString("attachment.txt"));
+    QCOMPARE(entry11->attachments()->keys().at(0), QStringLiteral("attachment.txt"));
     QCOMPARE(entry11->attachments()->value("attachment.txt"), QByteArray("hello world\n"));
 
     Entry* entry12 = group1->entries().at(1);
-    QCOMPARE(entry12->title(), QString(""));
+    QCOMPARE(entry12->title(), QString());
     QCOMPARE(entry12->iconNumber(), 0);
-    QCOMPARE(entry12->username(), QString(""));
-    QCOMPARE(entry12->url(), QString(""));
-    QCOMPARE(entry12->password(), QString(""));
-    QCOMPARE(entry12->notes(), QString(""));
+    QCOMPARE(entry12->username(), QString());
+    QCOMPARE(entry12->url(), QString());
+    QCOMPARE(entry12->password(), QString());
+    QCOMPARE(entry12->notes(), QString());
     QVERIFY(!entry12->timeInfo().expires());
     QCOMPARE(entry12->attachments()->keys().size(), 0);
 
     Group* group11 = group1->children().at(0);
-    QCOMPARE(group11->name(), QString("Subgroup 1"));
+    QCOMPARE(group11->name(), QStringLiteral("Subgroup 1"));
     QCOMPARE(group11->children().size(), 1);
 
     Group* group111 = group11->children().at(0);
-    QCOMPARE(group111->name(), QString("Unexpanded"));
+    QCOMPARE(group111->name(), QStringLiteral("Unexpanded"));
     QCOMPARE(group111->children().size(), 1);
 
     Group* group1111 = group111->children().at(0);
-    QCOMPARE(group1111->name(), QString("abc"));
+    QCOMPARE(group1111->name(), QStringLiteral("abc"));
     QCOMPARE(group1111->children().size(), 0);
 
     Group* group12 = group1->children().at(1);
-    QCOMPARE(group12->name(), QString("Subgroup 2"));
+    QCOMPARE(group12->name(), QStringLiteral("Subgroup 2"));
     QCOMPARE(group12->children().size(), 0);
 
     Group* group2 = m_db->rootGroup()->children().at(1);
-    QCOMPARE(group2->name(), QString("eMail"));
+    QCOMPARE(group2->name(), QStringLiteral("eMail"));
     QCOMPARE(group2->entries().size(), 1);
     QCOMPARE(group2->iconNumber(), 19);
 
@@ -135,40 +135,40 @@ void TestKeePass1Reader::testAutoType()
     QCOMPARE(group->entries().size(), 2);
 
     Entry* entry1 = group->entries().at(0);
-    QCOMPARE(entry1->notes(), QString("last line"));
-    QCOMPARE(entry1->defaultAutoTypeSequence(), QString("{USERNAME}{ENTER}"));
+    QCOMPARE(entry1->notes(), QStringLiteral("last line"));
+    QCOMPARE(entry1->defaultAutoTypeSequence(), QStringLiteral("{USERNAME}{ENTER}"));
     QCOMPARE(entry1->autoTypeAssociations()->size(), 5);
-    QCOMPARE(entry1->autoTypeAssociations()->get(0).sequence, QString(""));
-    QCOMPARE(entry1->autoTypeAssociations()->get(0).window, QString("a window"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(1).sequence, QString(""));
-    QCOMPARE(entry1->autoTypeAssociations()->get(1).window, QString("a second window"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(2).sequence, QString("{PASSWORD}{ENTER}"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(2).window, QString("Window Nr 1a"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(3).sequence, QString("{PASSWORD}{ENTER}"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(3).window, QString("Window Nr 1b"));
-    QCOMPARE(entry1->autoTypeAssociations()->get(4).sequence, QString(""));
-    QCOMPARE(entry1->autoTypeAssociations()->get(4).window, QString("Window 2"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(0).sequence, QString());
+    QCOMPARE(entry1->autoTypeAssociations()->get(0).window, QStringLiteral("a window"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(1).sequence, QString());
+    QCOMPARE(entry1->autoTypeAssociations()->get(1).window, QStringLiteral("a second window"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(2).sequence, QStringLiteral("{PASSWORD}{ENTER}"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(2).window, QStringLiteral("Window Nr 1a"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(3).sequence, QStringLiteral("{PASSWORD}{ENTER}"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(3).window, QStringLiteral("Window Nr 1b"));
+    QCOMPARE(entry1->autoTypeAssociations()->get(4).sequence, QString());
+    QCOMPARE(entry1->autoTypeAssociations()->get(4).window, QStringLiteral("Window 2"));
 
     Entry* entry2 = group->entries().at(1);
-    QCOMPARE(entry2->notes(), QString("start line\nend line"));
-    QCOMPARE(entry2->defaultAutoTypeSequence(), QString(""));
+    QCOMPARE(entry2->notes(), QStringLiteral("start line\nend line"));
+    QCOMPARE(entry2->defaultAutoTypeSequence(), QString());
     QCOMPARE(entry2->autoTypeAssociations()->size(), 2);
-    QCOMPARE(entry2->autoTypeAssociations()->get(0).sequence, QString(""));
-    QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QString("Main Window"));
-    QCOMPARE(entry2->autoTypeAssociations()->get(1).sequence, QString(""));
-    QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QString("Test Window"));
+    QCOMPARE(entry2->autoTypeAssociations()->get(0).sequence, QString());
+    QCOMPARE(entry2->autoTypeAssociations()->get(0).window, QStringLiteral("Main Window"));
+    QCOMPARE(entry2->autoTypeAssociations()->get(1).sequence, QString());
+    QCOMPARE(entry2->autoTypeAssociations()->get(1).window, QStringLiteral("Test Window"));
 }
 
 void TestKeePass1Reader::testFileKey()
 {
     QFETCH(QString, type);
 
-    QString name = QString("FileKey").append(type);
+    QString name = QStringLiteral("FileKey").append(type);
 
     KeePass1Reader reader;
 
-    QString dbFilename = QString("%1/%2.kdb").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
-    QString keyFilename = QString("%1/%2.key").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
+    QString dbFilename = QStringLiteral("%1/%2.kdb").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
+    QString keyFilename = QStringLiteral("%1/%2.key").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
 
     auto db = reader.readDatabase(dbFilename, QString(), keyFilename);
     QVERIFY(db);
@@ -182,9 +182,9 @@ void TestKeePass1Reader::testFileKey()
 void TestKeePass1Reader::testFileKey_data()
 {
     QTest::addColumn<QString>("type");
-    QTest::newRow("Binary") << QString("Binary");
-    QTest::newRow("Hex") << QString("Hex");
-    QTest::newRow("Hashed") << QString("Hashed");
+    QTest::newRow("Binary") << QStringLiteral("Binary");
+    QTest::newRow("Hex") << QStringLiteral("Hex");
+    QTest::newRow("Hashed") << QStringLiteral("Hashed");
 }
 
 void TestKeePass1Reader::testCompositeKey()
@@ -193,8 +193,8 @@ void TestKeePass1Reader::testCompositeKey()
 
     KeePass1Reader reader;
 
-    QString dbFilename = QString("%1/%2.kdb").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
-    QString keyFilename = QString("%1/FileKeyHex.key").arg(QString(KEEPASSX_TEST_DATA_DIR));
+    QString dbFilename = QStringLiteral("%1/%2.kdb").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
+    QString keyFilename = QStringLiteral("%1/FileKeyHex.key").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR));
 
     auto db = reader.readDatabase(dbFilename, "mypassword", keyFilename);
     QVERIFY(db);
@@ -211,7 +211,7 @@ void TestKeePass1Reader::testTwofish()
 
     KeePass1Reader reader;
 
-    QString dbFilename = QString("%1/%2.kdb").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
+    QString dbFilename = QStringLiteral("%1/%2.kdb").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
 
     auto db = reader.readDatabase(dbFilename, "masterpw", nullptr);
     QVERIFY(db);
@@ -226,7 +226,7 @@ void TestKeePass1Reader::testCP1252Password()
 
     KeePass1Reader reader;
 
-    QString dbFilename = QString("%1/%2.kdb").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
+    QString dbFilename = QStringLiteral("%1/%2.kdb").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
     QString password = QString::fromUtf8("\xe2\x80\x9e\x70\x61\x73\x73\x77\x6f\x72\x64\xe2\x80\x9d");
 
     auto db = reader.readDatabase(dbFilename, password, nullptr);

--- a/tests/TestKeePass2Format.cpp
+++ b/tests/TestKeePass2Format.cpp
@@ -36,9 +36,9 @@ void TestKeePass2Format::initTestCase()
     // read raw XML database
     bool hasError;
     QString errorString;
-    m_xmlDb = readXml(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml"), true, hasError, errorString);
+    m_xmlDb = readXml(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.xml"), true, hasError, errorString);
     if (hasError) {
-        QFAIL(qPrintable(QString("Error while reading XML: ").append(errorString)));
+        QFAIL(qPrintable(QStringLiteral("Error while reading XML: ").append(errorString)));
     }
     QVERIFY(m_xmlDb.data());
 
@@ -69,7 +69,7 @@ void TestKeePass2Format::initTestCase()
     m_kdbxTargetBuffer.open(QBuffer::ReadWrite);
     writeKdbx(&m_kdbxTargetBuffer, m_kdbxSourceDb.data(), hasError, errorString);
     if (hasError) {
-        QFAIL(qPrintable(QString("Error while writing database: ").append(errorString)));
+        QFAIL(qPrintable(QStringLiteral("Error while writing database: ").append(errorString)));
     }
 
     // call sub class init method
@@ -78,15 +78,15 @@ void TestKeePass2Format::initTestCase()
 
 void TestKeePass2Format::testXmlMetadata()
 {
-    QCOMPARE(m_xmlDb->metadata()->generator(), QString("KeePass"));
-    QCOMPARE(m_xmlDb->metadata()->name(), QString("ANAME"));
+    QCOMPARE(m_xmlDb->metadata()->generator(), QStringLiteral("KeePass"));
+    QCOMPARE(m_xmlDb->metadata()->name(), QStringLiteral("ANAME"));
     QCOMPARE(m_xmlDb->metadata()->nameChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 24, 53));
-    QCOMPARE(m_xmlDb->metadata()->description(), QString("ADESC"));
+    QCOMPARE(m_xmlDb->metadata()->description(), QStringLiteral("ADESC"));
     QCOMPARE(m_xmlDb->metadata()->descriptionChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 27, 12));
-    QCOMPARE(m_xmlDb->metadata()->defaultUserName(), QString("DEFUSERNAME"));
+    QCOMPARE(m_xmlDb->metadata()->defaultUserName(), QStringLiteral("DEFUSERNAME"));
     QCOMPARE(m_xmlDb->metadata()->defaultUserNameChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 27, 45));
     QCOMPARE(m_xmlDb->metadata()->maintenanceHistoryDays(), 127);
-    QCOMPARE(m_xmlDb->metadata()->color(), QString("#FFEF00"));
+    QCOMPARE(m_xmlDb->metadata()->color(), QStringLiteral("#FFEF00"));
     QCOMPARE(m_xmlDb->metadata()->databaseKeyChanged(), MockClock::datetimeUtc(2012, 4, 5, 17, 9, 34));
     QCOMPARE(m_xmlDb->metadata()->databaseKeyChangeRec(), 101);
     QCOMPARE(m_xmlDb->metadata()->databaseKeyChangeForce(), -1);
@@ -97,12 +97,12 @@ void TestKeePass2Format::testXmlMetadata()
     QCOMPARE(m_xmlDb->metadata()->protectNotes(), false);
     QCOMPARE(m_xmlDb->metadata()->recycleBinEnabled(), true);
     QVERIFY(m_xmlDb->metadata()->recycleBin() != nullptr);
-    QCOMPARE(m_xmlDb->metadata()->recycleBin()->name(), QString("Recycle Bin"));
+    QCOMPARE(m_xmlDb->metadata()->recycleBin()->name(), QStringLiteral("Recycle Bin"));
     QCOMPARE(m_xmlDb->metadata()->recycleBinChanged(), MockClock::datetimeUtc(2010, 8, 25, 16, 12, 57));
     QVERIFY(m_xmlDb->metadata()->entryTemplatesGroup() == nullptr);
     QCOMPARE(m_xmlDb->metadata()->entryTemplatesGroupChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 24, 19));
     QVERIFY(m_xmlDb->metadata()->lastSelectedGroup() != nullptr);
-    QCOMPARE(m_xmlDb->metadata()->lastSelectedGroup()->name(), QString("NewDatabase"));
+    QCOMPARE(m_xmlDb->metadata()->lastSelectedGroup()->name(), QStringLiteral("NewDatabase"));
     QVERIFY(m_xmlDb->metadata()->lastTopVisibleGroup() == m_xmlDb->metadata()->lastSelectedGroup());
     QCOMPARE(m_xmlDb->metadata()->historyMaxItems(), -1);
     QCOMPARE(m_xmlDb->metadata()->historyMaxSize(), 5242880);
@@ -124,8 +124,8 @@ void TestKeePass2Format::testXmlGroupRoot()
     const Group* group = m_xmlDb->rootGroup();
     QVERIFY(group);
     QCOMPARE(group->uuid(), QUuid::fromRfc4122(QByteArray::fromBase64("lmU+9n0aeESKZvcEze+bRg==")));
-    QCOMPARE(group->name(), QString("NewDatabase"));
-    QCOMPARE(group->notes(), QString(""));
+    QCOMPARE(group->name(), QStringLiteral("NewDatabase"));
+    QCOMPARE(group->notes(), QString());
     QCOMPARE(group->iconNumber(), 49);
     QCOMPARE(group->iconUuid(), QUuid());
     QVERIFY(group->isExpanded());
@@ -137,7 +137,7 @@ void TestKeePass2Format::testXmlGroupRoot()
     QVERIFY(!ti.expires());
     QCOMPARE(ti.usageCount(), 52);
     QCOMPARE(ti.locationChanged(), MockClock::datetimeUtc(2010, 8, 8, 17, 24, 27));
-    QCOMPARE(group->defaultAutoTypeSequence(), QString(""));
+    QCOMPARE(group->defaultAutoTypeSequence(), QString());
     QCOMPARE(group->autoTypeEnabled(), Group::Inherit);
     QCOMPARE(group->searchingEnabled(), Group::Inherit);
     QCOMPARE(group->lastTopVisibleEntry()->uuid(),
@@ -153,12 +153,12 @@ void TestKeePass2Format::testXmlGroup1()
     const Group* group = m_xmlDb->rootGroup()->children().at(0);
 
     QCOMPARE(group->uuid(), QUuid::fromRfc4122(QByteArray::fromBase64("AaUYVdXsI02h4T1RiAlgtg==")));
-    QCOMPARE(group->name(), QString("General"));
-    QCOMPARE(group->notes(), QString("Group Notez"));
+    QCOMPARE(group->name(), QStringLiteral("General"));
+    QCOMPARE(group->notes(), QStringLiteral("Group Notez"));
     QCOMPARE(group->iconNumber(), 48);
     QCOMPARE(group->iconUuid(), QUuid());
     QCOMPARE(group->isExpanded(), true);
-    QCOMPARE(group->defaultAutoTypeSequence(), QString("{Password}{ENTER}"));
+    QCOMPARE(group->defaultAutoTypeSequence(), QStringLiteral("{Password}{ENTER}"));
     QCOMPARE(group->autoTypeEnabled(), Group::Enable);
     QCOMPARE(group->searchingEnabled(), Group::Disable);
     QVERIFY(!group->lastTopVisibleEntry());
@@ -169,19 +169,19 @@ void TestKeePass2Format::testXmlGroup2()
     const Group* group = m_xmlDb->rootGroup()->children().at(1);
 
     QCOMPARE(group->uuid(), QUuid::fromRfc4122(QByteArray::fromBase64("1h4NtL5DK0yVyvaEnN//4A==")));
-    QCOMPARE(group->name(), QString("Windows"));
+    QCOMPARE(group->name(), QStringLiteral("Windows"));
     QCOMPARE(group->isExpanded(), false);
 
     QCOMPARE(group->children().size(), 1);
     const Group* child = group->children().first();
 
     QCOMPARE(child->uuid(), QUuid::fromRfc4122(QByteArray::fromBase64("HoYE/BjLfUSW257pCHJ/eA==")));
-    QCOMPARE(child->name(), QString("Subsub"));
+    QCOMPARE(child->name(), QStringLiteral("Subsub"));
     QCOMPARE(child->entries().size(), 1);
 
     const Entry* entry = child->entries().first();
     QCOMPARE(entry->uuid(), QUuid::fromRfc4122(QByteArray::fromBase64("GZpdQvGXOU2kaKRL/IVAGg==")));
-    QCOMPARE(entry->title(), QString("Subsub Entry"));
+    QCOMPARE(entry->title(), QStringLiteral("Subsub Entry"));
 }
 
 void TestKeePass2Format::testXmlEntry1()
@@ -194,8 +194,8 @@ void TestKeePass2Format::testXmlEntry1()
     QCOMPARE(entry->iconUuid(), QUuid());
     QVERIFY(entry->foregroundColor().isEmpty());
     QVERIFY(entry->backgroundColor().isEmpty());
-    QCOMPARE(entry->overrideUrl(), QString(""));
-    QCOMPARE(entry->tags(), QString("a b c"));
+    QCOMPARE(entry->overrideUrl(), QString());
+    QCOMPARE(entry->tags(), QStringLiteral("a b c"));
 
     const TimeInfo ti = entry->timeInfo();
     QCOMPARE(ti.lastModificationTime(), MockClock::datetimeUtc(2010, 8, 25, 16, 19, 25));
@@ -207,19 +207,19 @@ void TestKeePass2Format::testXmlEntry1()
     QCOMPARE(ti.locationChanged(), MockClock::datetimeUtc(2010, 8, 25, 16, 13, 54));
 
     QList<QString> attrs = entry->attributes()->keys();
-    QCOMPARE(entry->attributes()->value("Notes"), QString("Notes"));
+    QCOMPARE(entry->attributes()->value("Notes"), QStringLiteral("Notes"));
     QVERIFY(!entry->attributes()->isProtected("Notes"));
     QVERIFY(attrs.removeOne("Notes"));
-    QCOMPARE(entry->attributes()->value("Password"), QString("Password"));
+    QCOMPARE(entry->attributes()->value("Password"), QStringLiteral("Password"));
     QVERIFY(!entry->attributes()->isProtected("Password"));
     QVERIFY(attrs.removeOne("Password"));
-    QCOMPARE(entry->attributes()->value("Title"), QString("Sample Entry 1"));
+    QCOMPARE(entry->attributes()->value("Title"), QStringLiteral("Sample Entry 1"));
     QVERIFY(!entry->attributes()->isProtected("Title"));
     QVERIFY(attrs.removeOne("Title"));
-    QCOMPARE(entry->attributes()->value("URL"), QString(""));
+    QCOMPARE(entry->attributes()->value("URL"), QString());
     QVERIFY(entry->attributes()->isProtected("URL"));
     QVERIFY(attrs.removeOne("URL"));
-    QCOMPARE(entry->attributes()->value("UserName"), QString("User Name"));
+    QCOMPARE(entry->attributes()->value("UserName"), QStringLiteral("User Name"));
     QVERIFY(entry->attributes()->isProtected("UserName"));
     QVERIFY(attrs.removeOne("UserName"));
     QVERIFY(attrs.isEmpty());
@@ -239,11 +239,11 @@ void TestKeePass2Format::testXmlEntry1()
 
     QCOMPARE(entry->autoTypeEnabled(), false);
     QCOMPARE(entry->autoTypeObfuscation(), 0);
-    QCOMPARE(entry->defaultAutoTypeSequence(), QString(""));
+    QCOMPARE(entry->defaultAutoTypeSequence(), QString());
     QCOMPARE(entry->autoTypeAssociations()->size(), 1);
     const AutoTypeAssociations::Association assoc1 = entry->autoTypeAssociations()->get(0);
-    QCOMPARE(assoc1.window, QString("Target Window"));
-    QCOMPARE(assoc1.sequence, QString(""));
+    QCOMPARE(assoc1.window, QStringLiteral("Target Window"));
+    QCOMPARE(assoc1.sequence, QString());
 }
 
 void TestKeePass2Format::testXmlEntry2()
@@ -254,44 +254,44 @@ void TestKeePass2Format::testXmlEntry2()
     QCOMPARE(entry->iconNumber(), 0);
     QCOMPARE(entry->iconUuid(), QUuid::fromRfc4122(QByteArray::fromBase64("++vyI+daLk6omox4a6kQGA==")));
     // TODO: test entry->icon()
-    QCOMPARE(entry->foregroundColor(), QString("#FF0000"));
-    QCOMPARE(entry->backgroundColor(), QString("#FFFF00"));
-    QCOMPARE(entry->overrideUrl(), QString("http://override.net/"));
-    QCOMPARE(entry->tags(), QString(""));
+    QCOMPARE(entry->foregroundColor(), QStringLiteral("#FF0000"));
+    QCOMPARE(entry->backgroundColor(), QStringLiteral("#FFFF00"));
+    QCOMPARE(entry->overrideUrl(), QStringLiteral("http://override.net/"));
+    QCOMPARE(entry->tags(), QString());
 
     const TimeInfo ti = entry->timeInfo();
     QCOMPARE(ti.usageCount(), 7);
 
     QList<QString> attrs = entry->attributes()->keys();
-    QCOMPARE(entry->attributes()->value("CustomString"), QString("isavalue"));
+    QCOMPARE(entry->attributes()->value("CustomString"), QStringLiteral("isavalue"));
     QVERIFY(attrs.removeOne("CustomString"));
-    QCOMPARE(entry->attributes()->value("Notes"), QString(""));
+    QCOMPARE(entry->attributes()->value("Notes"), QString());
     QVERIFY(attrs.removeOne("Notes"));
-    QCOMPARE(entry->attributes()->value("Password"), QString("Jer60Hz8o9XHvxBGcRqT"));
+    QCOMPARE(entry->attributes()->value("Password"), QStringLiteral("Jer60Hz8o9XHvxBGcRqT"));
     QVERIFY(attrs.removeOne("Password"));
-    QCOMPARE(entry->attributes()->value("Protected String"), QString("y")); // TODO: should have a protection attribute
+    QCOMPARE(entry->attributes()->value("Protected String"), QStringLiteral("y")); // TODO: should have a protection attribute
     QVERIFY(attrs.removeOne("Protected String"));
-    QCOMPARE(entry->attributes()->value("Title"), QString("Sample Entry 2"));
+    QCOMPARE(entry->attributes()->value("Title"), QStringLiteral("Sample Entry 2"));
     QVERIFY(attrs.removeOne("Title"));
-    QCOMPARE(entry->attributes()->value("URL"), QString("http://www.keepassx.org/"));
+    QCOMPARE(entry->attributes()->value("URL"), QStringLiteral("http://www.keepassx.org/"));
     QVERIFY(attrs.removeOne("URL"));
-    QCOMPARE(entry->attributes()->value("UserName"), QString("notDEFUSERNAME"));
+    QCOMPARE(entry->attributes()->value("UserName"), QStringLiteral("notDEFUSERNAME"));
     QVERIFY(attrs.removeOne("UserName"));
     QVERIFY(attrs.isEmpty());
 
     QCOMPARE(entry->attachments()->keys().size(), 1);
-    QCOMPARE(QString::fromLatin1(entry->attachments()->value("myattach.txt")), QString("abcdefghijk"));
+    QCOMPARE(QString::fromLatin1(entry->attachments()->value("myattach.txt")), QStringLiteral("abcdefghijk"));
 
     QCOMPARE(entry->autoTypeEnabled(), true);
     QCOMPARE(entry->autoTypeObfuscation(), 1);
-    QCOMPARE(entry->defaultAutoTypeSequence(), QString("{USERNAME}{TAB}{PASSWORD}{ENTER}"));
+    QCOMPARE(entry->defaultAutoTypeSequence(), QStringLiteral("{USERNAME}{TAB}{PASSWORD}{ENTER}"));
     QCOMPARE(entry->autoTypeAssociations()->size(), 2);
     const AutoTypeAssociations::Association assoc1 = entry->autoTypeAssociations()->get(0);
-    QCOMPARE(assoc1.window, QString("Target Window"));
-    QCOMPARE(assoc1.sequence, QString("{Title}{UserName}"));
+    QCOMPARE(assoc1.window, QStringLiteral("Target Window"));
+    QCOMPARE(assoc1.sequence, QStringLiteral("{Title}{UserName}"));
     const AutoTypeAssociations::Association assoc2 = entry->autoTypeAssociations()->get(1);
-    QCOMPARE(assoc2.window, QString("Target Window 2"));
-    QCOMPARE(assoc2.sequence, QString("{Title}{UserName} test"));
+    QCOMPARE(assoc2.window, QStringLiteral("Target Window 2"));
+    QCOMPARE(assoc2.sequence, QStringLiteral("{Title}{UserName} test"));
 }
 
 void TestKeePass2Format::testXmlEntryHistory()
@@ -305,8 +305,8 @@ void TestKeePass2Format::testXmlEntryHistory()
         QVERIFY(!entry->parent());
         QCOMPARE(entry->timeInfo().lastModificationTime(), MockClock::datetimeUtc(2010, 8, 25, 16, 13, 54));
         QCOMPARE(entry->timeInfo().usageCount(), 3);
-        QCOMPARE(entry->title(), QString("Sample Entry"));
-        QCOMPARE(entry->url(), QString("http://www.somesite.com/"));
+        QCOMPARE(entry->title(), QStringLiteral("Sample Entry"));
+        QCOMPARE(entry->url(), QStringLiteral("http://www.somesite.com/"));
     }
 
     {
@@ -315,8 +315,8 @@ void TestKeePass2Format::testXmlEntryHistory()
         QVERIFY(!entry->parent());
         QCOMPARE(entry->timeInfo().lastModificationTime(), MockClock::datetimeUtc(2010, 8, 25, 16, 15, 43));
         QCOMPARE(entry->timeInfo().usageCount(), 7);
-        QCOMPARE(entry->title(), QString("Sample Entry 1"));
-        QCOMPARE(entry->url(), QString("http://www.somesite.com/"));
+        QCOMPARE(entry->title(), QStringLiteral("Sample Entry 1"));
+        QCOMPARE(entry->url(), QStringLiteral("http://www.somesite.com/"));
     }
 }
 
@@ -342,7 +342,7 @@ void TestKeePass2Format::testXmlBroken()
     QFETCH(bool, strictMode);
     QFETCH(bool, expectError);
 
-    QString xmlFile = QString("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, baseName);
+    QString xmlFile = QStringLiteral("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, baseName);
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
@@ -383,7 +383,7 @@ void TestKeePass2Format::testXmlBroken_data()
 void TestKeePass2Format::testXmlEmptyUuids()
 {
 
-    QString xmlFile = QString("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, "EmptyUuids");
+    QString xmlFile = QStringLiteral("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, "EmptyUuids");
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
@@ -454,10 +454,10 @@ void TestKeePass2Format::testXmlInvalidXmlChars()
     QCOMPARE(attrRead->value("PlainInvalid"), QString());
     QCOMPARE(attrRead->value("PlainValid"), strPlainValid);
     QCOMPARE(attrRead->value("SingleHighSurrogate1"), QString());
-    QCOMPARE(attrRead->value("SingleHighSurrogate2"), QString("12"));
+    QCOMPARE(attrRead->value("SingleHighSurrogate2"), QStringLiteral("12"));
     QCOMPARE(attrRead->value("HighHighSurrogate"), QString());
     QCOMPARE(attrRead->value("SingleLowSurrogate1"), QString());
-    QCOMPARE(attrRead->value("SingleLowSurrogate2"), QString("12"));
+    QCOMPARE(attrRead->value("SingleLowSurrogate2"), QStringLiteral("12"));
     QCOMPARE(attrRead->value("LowLowSurrogate"), QString());
     QCOMPARE(attrRead->value("SurrogateValid1"), strSurrogateValid1);
     QCOMPARE(attrRead->value("SurrogateValid2"), strSurrogateValid2);
@@ -465,7 +465,7 @@ void TestKeePass2Format::testXmlInvalidXmlChars()
 
 void TestKeePass2Format::testXmlRepairUuidHistoryItem()
 {
-    QString xmlFile = QString("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, "BrokenDifferentEntryHistoryUuid");
+    QString xmlFile = QStringLiteral("%1/%2.xml").arg(KEEPASSX_TEST_DATA_DIR, "BrokenDifferentEntryHistoryUuid");
     QVERIFY(QFile::exists(xmlFile));
     bool hasError;
     QString errorString;
@@ -501,7 +501,7 @@ void TestKeePass2Format::testReadBackTargetDb()
     m_kdbxTargetDb = QSharedPointer<Database>::create();
     readKdbx(&m_kdbxTargetBuffer, key, m_kdbxTargetDb, hasError, errorString);
     if (hasError) {
-        QFAIL(qPrintable(QString("Error while reading database: ").append(errorString)));
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: ").append(errorString)));
     }
     QVERIFY(m_kdbxTargetDb.data());
 }
@@ -519,7 +519,7 @@ void TestKeePass2Format::testKdbxProtectedAttributes()
 {
     QCOMPARE(m_kdbxTargetDb->rootGroup()->entries().size(), 1);
     Entry* entry = m_kdbxTargetDb->rootGroup()->entries().at(0);
-    QCOMPARE(entry->attributes()->value("test"), QString("protectedTest"));
+    QCOMPARE(entry->attributes()->value("test"), QStringLiteral("protectedTest"));
     QCOMPARE(entry->attributes()->isProtected("test"), true);
 }
 
@@ -557,7 +557,7 @@ void TestKeePass2Format::testKdbxDeviceFailure()
     QString errorString;
     writeKdbx(&failDevice, db.data(), hasError, errorString);
     QVERIFY(hasError);
-    QCOMPARE(errorString, QString("FAILDEVICE"));
+    QCOMPARE(errorString, QStringLiteral("FAILDEVICE"));
 }
 
 Q_DECLARE_METATYPE(QSharedPointer<CompositeKey>)
@@ -769,13 +769,13 @@ void TestKeePass2Format::testDuplicateAttachments()
     QString errorString;
     writeKdbx(&buffer, db.data(), hasError, errorString);
     if (hasError) {
-        QFAIL(qPrintable(QString("Error while writing database: %1").arg(errorString)));
+        QFAIL(qPrintable(QStringLiteral("Error while writing database: %1").arg(errorString)));
     }
 
     buffer.seek(0);
     readKdbx(&buffer, QSharedPointer<CompositeKey>::create(), db, hasError, errorString);
     if (hasError) {
-        QFAIL(qPrintable(QString("Error while reading database: %1").arg(errorString)));
+        QFAIL(qPrintable(QStringLiteral("Error while reading database: %1").arg(errorString)));
     }
 
     QCOMPARE(db->rootGroup()->entries()[0]->attachments()->value("a"), attachment1);

--- a/tests/TestKeys.cpp
+++ b/tests/TestKeys.cpp
@@ -79,12 +79,12 @@ void TestKeys::testFileKey()
     QFETCH(QString, keyExt);
     QFETCH(bool, fileKeyOk);
 
-    QString name = QString("FileKey").append(QTest::currentDataTag());
+    QString name = QStringLiteral("FileKey").append(QTest::currentDataTag());
 
     KeePass2Reader reader;
 
-    QString dbFilename = QString("%1/%2.kdbx").arg(QString(KEEPASSX_TEST_DATA_DIR), name);
-    QString keyFilename = QString("%1/%2.%3").arg(QString(KEEPASSX_TEST_DATA_DIR), name, keyExt);
+    QString dbFilename = QStringLiteral("%1/%2.kdbx").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name);
+    QString keyFilename = QStringLiteral("%1/%2.%3").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), name, keyExt);
 
     auto compositeKey = QSharedPointer<CompositeKey>::create();
     auto fileKey = QSharedPointer<FileKey>::create();
@@ -111,7 +111,7 @@ void TestKeys::testFileKey()
     auto db = QSharedPointer<Database>::create();
     QVERIFY(db->open(dbFilename, compositeKey, nullptr));
     QVERIFY(!reader.hasError());
-    QCOMPARE(db->metadata()->name(), QString("%1 Database").arg(name));
+    QCOMPARE(db->metadata()->name(), QStringLiteral("%1 Database").arg(name));
 }
 
 // clang-format off
@@ -120,14 +120,14 @@ void TestKeys::testFileKey_data()
     QTest::addColumn<FileKey::Type>("type");
     QTest::addColumn<QString>("keyExt");
     QTest::addColumn<bool>("fileKeyOk");
-    QTest::newRow("Xml")             << FileKey::KeePass2XML    << QString("key")  << true;
-    QTest::newRow("XmlBrokenBase64") << FileKey::KeePass2XML    << QString("key")  << false;
-    QTest::newRow("XmlV2")           << FileKey::KeePass2XMLv2  << QString("keyx") << true;
-    QTest::newRow("XmlV2HashFail")   << FileKey::KeePass2XMLv2  << QString("keyx") << false;
-    QTest::newRow("XmlV2BrokenHex")  << FileKey::KeePass2XMLv2  << QString("keyx") << false;
-    QTest::newRow("Binary")          << FileKey::FixedBinary    << QString("key")  << true;
-    QTest::newRow("Hex")             << FileKey::FixedBinaryHex << QString("key")  << true;
-    QTest::newRow("Hashed")          << FileKey::Hashed         << QString("key")  << true;
+    QTest::newRow("Xml")             << FileKey::KeePass2XML    << QStringLiteral("key")  << true;
+    QTest::newRow("XmlBrokenBase64") << FileKey::KeePass2XML    << QStringLiteral("key")  << false;
+    QTest::newRow("XmlV2")           << FileKey::KeePass2XMLv2  << QStringLiteral("keyx") << true;
+    QTest::newRow("XmlV2HashFail")   << FileKey::KeePass2XMLv2  << QStringLiteral("keyx") << false;
+    QTest::newRow("XmlV2BrokenHex")  << FileKey::KeePass2XMLv2  << QStringLiteral("keyx") << false;
+    QTest::newRow("Binary")          << FileKey::FixedBinary    << QStringLiteral("key")  << true;
+    QTest::newRow("Hex")             << FileKey::FixedBinaryHex << QStringLiteral("key")  << true;
+    QTest::newRow("Hashed")          << FileKey::Hashed         << QStringLiteral("key")  << true;
 }
 // clang-format on
 
@@ -206,7 +206,7 @@ void TestKeys::testFileKeyError()
 {
     bool result;
     QString errorMsg;
-    const QString fileName(QString(KEEPASSX_TEST_DATA_DIR).append("/does/not/exist"));
+    const QString fileName(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/does/not/exist"));
 
     FileKey fileKey;
     result = fileKey.load(fileName, &errorMsg);
@@ -251,7 +251,7 @@ void TestKeys::testCompositeKeyComponents()
     auto passwordKeyEnc = QSharedPointer<PasswordKey>::create("password");
     auto fileKeyEnc = QSharedPointer<FileKey>::create();
     QString error;
-    fileKeyEnc->load(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"), &error);
+    fileKeyEnc->load(QStringLiteral("%1/%2").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"), &error);
     if (!error.isEmpty()) {
         QFAIL(qPrintable(error));
     }
@@ -309,7 +309,7 @@ void TestKeys::testCompositeKeyComponents()
     auto compositeKeyDec3 = QSharedPointer<CompositeKey>::create();
     compositeKeyDec3->addKey(passwordKeyEnc);
     auto fileKeyWrong = QSharedPointer<FileKey>::create();
-    fileKeyWrong->load(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed2.key"), &error);
+    fileKeyWrong->load(QStringLiteral("%1/%2").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed2.key"), &error);
     if (!error.isEmpty()) {
         QFAIL(qPrintable(error));
     }

--- a/tests/TestMerge.cpp
+++ b/tests/TestMerge.cpp
@@ -157,7 +157,7 @@ void TestMerge::testResolveConflictNewer()
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
-    QCOMPARE(entryDestinationMerged->password(), QString("password"));
+    QCOMPARE(entryDestinationMerged->password(), QStringLiteral("password"));
     QCOMPARE(entryDestinationMerged->timeInfo(), entrySourceUpdatedTimeInfo);
 
     // When updating an entry, it should not end up in the
@@ -241,7 +241,7 @@ void TestMerge::testResolveConflictExisting()
 
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
-    QCOMPARE(entryDestinationMerged->password(), QString("password2"));
+    QCOMPARE(entryDestinationMerged->password(), QStringLiteral("password2"));
     QCOMPARE(entryDestinationMerged->timeInfo(), entryDestinationUpdatedNewerTimeInfo);
 
     // When updating an entry, it should not end up in the
@@ -602,78 +602,78 @@ void TestMerge::assertDeletionLocalOnly(Database* db, const QMap<QString, QUuid>
 void TestMerge::assertUpdateMergedEntry1(Entry* mergedEntry1, const QMap<const char*, QDateTime>& timestamps)
 {
     QCOMPARE(mergedEntry1->historyItems().count(), 4);
-    QCOMPARE(mergedEntry1->historyItems().at(0)->notes(), QString(""));
+    QCOMPARE(mergedEntry1->historyItems().at(0)->notes(), QString());
     QCOMPARE(mergedEntry1->historyItems().at(0)->timeInfo().lastModificationTime(), timestamps["initialTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(1)->notes(), QString(""));
+    QCOMPARE(mergedEntry1->historyItems().at(1)->notes(), QString());
     QCOMPARE(mergedEntry1->historyItems().at(1)->timeInfo().lastModificationTime(),
              timestamps["oldestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(2)->notes(), QString("1 Common"));
+    QCOMPARE(mergedEntry1->historyItems().at(2)->notes(), QStringLiteral("1 Common"));
     QCOMPARE(mergedEntry1->historyItems().at(2)->timeInfo().lastModificationTime(),
              timestamps["newestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(3)->notes(), QString("2 Source"));
+    QCOMPARE(mergedEntry1->historyItems().at(3)->notes(), QStringLiteral("2 Source"));
     QCOMPARE(mergedEntry1->historyItems().at(3)->timeInfo().lastModificationTime(),
              timestamps["oldestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry1->notes(), QString("3 Destination"));
+    QCOMPARE(mergedEntry1->notes(), QStringLiteral("3 Destination"));
     QCOMPARE(mergedEntry1->timeInfo().lastModificationTime(), timestamps["newestDivergingHistoryTime"]);
 }
 
 void TestMerge::assertUpdateReappliedEntry2(Entry* mergedEntry2, const QMap<const char*, QDateTime>& timestamps)
 {
     QCOMPARE(mergedEntry2->historyItems().count(), 5);
-    QCOMPARE(mergedEntry2->historyItems().at(0)->notes(), QString(""));
+    QCOMPARE(mergedEntry2->historyItems().at(0)->notes(), QString());
     QCOMPARE(mergedEntry2->historyItems().at(0)->timeInfo().lastModificationTime(), timestamps["initialTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(1)->notes(), QString(""));
+    QCOMPARE(mergedEntry2->historyItems().at(1)->notes(), QString());
     QCOMPARE(mergedEntry2->historyItems().at(1)->timeInfo().lastModificationTime(),
              timestamps["oldestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(2)->notes(), QString("1 Common"));
+    QCOMPARE(mergedEntry2->historyItems().at(2)->notes(), QStringLiteral("1 Common"));
     QCOMPARE(mergedEntry2->historyItems().at(2)->timeInfo().lastModificationTime(),
              timestamps["newestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(3)->notes(), QString("2 Destination"));
+    QCOMPARE(mergedEntry2->historyItems().at(3)->notes(), QStringLiteral("2 Destination"));
     QCOMPARE(mergedEntry2->historyItems().at(3)->timeInfo().lastModificationTime(),
              timestamps["oldestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(4)->notes(), QString("3 Source"));
+    QCOMPARE(mergedEntry2->historyItems().at(4)->notes(), QStringLiteral("3 Source"));
     QCOMPARE(mergedEntry2->historyItems().at(4)->timeInfo().lastModificationTime(),
              timestamps["newestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry2->notes(), QString("2 Destination"));
+    QCOMPARE(mergedEntry2->notes(), QStringLiteral("2 Destination"));
     QCOMPARE(mergedEntry2->timeInfo().lastModificationTime(), timestamps["mergeTime"]);
 }
 
 void TestMerge::assertUpdateReappliedEntry1(Entry* mergedEntry1, const QMap<const char*, QDateTime>& timestamps)
 {
     QCOMPARE(mergedEntry1->historyItems().count(), 5);
-    QCOMPARE(mergedEntry1->historyItems().at(0)->notes(), QString(""));
+    QCOMPARE(mergedEntry1->historyItems().at(0)->notes(), QString());
     QCOMPARE(mergedEntry1->historyItems().at(0)->timeInfo().lastModificationTime(), timestamps["initialTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(1)->notes(), QString(""));
+    QCOMPARE(mergedEntry1->historyItems().at(1)->notes(), QString());
     QCOMPARE(mergedEntry1->historyItems().at(1)->timeInfo().lastModificationTime(),
              timestamps["oldestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(2)->notes(), QString("1 Common"));
+    QCOMPARE(mergedEntry1->historyItems().at(2)->notes(), QStringLiteral("1 Common"));
     QCOMPARE(mergedEntry1->historyItems().at(2)->timeInfo().lastModificationTime(),
              timestamps["newestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(3)->notes(), QString("2 Source"));
+    QCOMPARE(mergedEntry1->historyItems().at(3)->notes(), QStringLiteral("2 Source"));
     QCOMPARE(mergedEntry1->historyItems().at(3)->timeInfo().lastModificationTime(),
              timestamps["oldestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry1->historyItems().at(4)->notes(), QString("3 Destination"));
+    QCOMPARE(mergedEntry1->historyItems().at(4)->notes(), QStringLiteral("3 Destination"));
     QCOMPARE(mergedEntry1->historyItems().at(4)->timeInfo().lastModificationTime(),
              timestamps["newestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry1->notes(), QString("2 Source"));
+    QCOMPARE(mergedEntry1->notes(), QStringLiteral("2 Source"));
     QCOMPARE(mergedEntry1->timeInfo().lastModificationTime(), timestamps["mergeTime"]);
 }
 
 void TestMerge::assertUpdateMergedEntry2(Entry* mergedEntry2, const QMap<const char*, QDateTime>& timestamps)
 {
     QCOMPARE(mergedEntry2->historyItems().count(), 4);
-    QCOMPARE(mergedEntry2->historyItems().at(0)->notes(), QString(""));
+    QCOMPARE(mergedEntry2->historyItems().at(0)->notes(), QString());
     QCOMPARE(mergedEntry2->historyItems().at(0)->timeInfo().lastModificationTime(), timestamps["initialTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(1)->notes(), QString(""));
+    QCOMPARE(mergedEntry2->historyItems().at(1)->notes(), QString());
     QCOMPARE(mergedEntry2->historyItems().at(1)->timeInfo().lastModificationTime(),
              timestamps["oldestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(2)->notes(), QString("1 Common"));
+    QCOMPARE(mergedEntry2->historyItems().at(2)->notes(), QStringLiteral("1 Common"));
     QCOMPARE(mergedEntry2->historyItems().at(2)->timeInfo().lastModificationTime(),
              timestamps["newestCommonHistoryTime"]);
-    QCOMPARE(mergedEntry2->historyItems().at(3)->notes(), QString("2 Destination"));
+    QCOMPARE(mergedEntry2->historyItems().at(3)->notes(), QStringLiteral("2 Destination"));
     QCOMPARE(mergedEntry2->historyItems().at(3)->timeInfo().lastModificationTime(),
              timestamps["oldestDivergingHistoryTime"]);
-    QCOMPARE(mergedEntry2->notes(), QString("3 Source"));
+    QCOMPARE(mergedEntry2->notes(), QStringLiteral("3 Source"));
     QCOMPARE(mergedEntry2->timeInfo().lastModificationTime(), timestamps["newestDivergingHistoryTime"]);
 }
 
@@ -730,7 +730,7 @@ void TestMerge::testMoveEntry()
     m_clock->advanceSecond(1);
 
     entrySourceInitial->setGroup(groupSourceInitial);
-    QCOMPARE(entrySourceInitial->group()->name(), QString("group2"));
+    QCOMPARE(entrySourceInitial->group()->name(), QStringLiteral("group2"));
 
     m_clock->advanceSecond(1);
 
@@ -739,7 +739,7 @@ void TestMerge::testMoveEntry()
 
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
-    QCOMPARE(entryDestinationMerged->group()->name(), QString("group2"));
+    QCOMPARE(entryDestinationMerged->group()->name(), QStringLiteral("group2"));
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
 }
 
@@ -763,7 +763,7 @@ void TestMerge::testMoveEntryPreserveChanges()
     m_clock->advanceSecond(1);
 
     entrySourceInitial->setGroup(group2Source);
-    QCOMPARE(entrySourceInitial->group()->name(), QString("group2"));
+    QCOMPARE(entrySourceInitial->group()->name(), QStringLiteral("group2"));
 
     QPointer<Entry> entryDestinationInitial = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationInitial != nullptr);
@@ -781,9 +781,9 @@ void TestMerge::testMoveEntryPreserveChanges()
 
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
-    QCOMPARE(entryDestinationMerged->group()->name(), QString("group2"));
+    QCOMPARE(entryDestinationMerged->group()->name(), QStringLiteral("group2"));
     QCOMPARE(dbDestination->rootGroup()->entriesRecursive().size(), 2);
-    QCOMPARE(entryDestinationMerged->password(), QString("password"));
+    QCOMPARE(entryDestinationMerged->password(), QStringLiteral("password"));
 }
 
 void TestMerge::testCreateNewGroups()
@@ -806,7 +806,7 @@ void TestMerge::testCreateNewGroups()
 
     QPointer<Group> groupDestinationMerged = dbDestination->rootGroup()->findChildByName("group3");
     QVERIFY(groupDestinationMerged != nullptr);
-    QCOMPARE(groupDestinationMerged->name(), QString("group3"));
+    QCOMPARE(groupDestinationMerged->name(), QStringLiteral("group3"));
 }
 
 void TestMerge::testMoveEntryIntoNewGroup()
@@ -834,12 +834,12 @@ void TestMerge::testMoveEntryIntoNewGroup()
 
     QPointer<Group> groupDestinationMerged = dbDestination->rootGroup()->findChildByName("group3");
     QVERIFY(groupDestinationMerged != nullptr);
-    QCOMPARE(groupDestinationMerged->name(), QString("group3"));
+    QCOMPARE(groupDestinationMerged->name(), QStringLiteral("group3"));
     QCOMPARE(groupDestinationMerged->entries().size(), 1);
 
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
-    QCOMPARE(entryDestinationMerged->group()->name(), QString("group3"));
+    QCOMPARE(entryDestinationMerged->group()->name(), QStringLiteral("group3"));
 }
 
 /**
@@ -887,8 +887,8 @@ void TestMerge::testUpdateEntryDifferentLocation()
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
-    QCOMPARE(entryDestinationMerged->username(), QString("username"));
-    QCOMPARE(entryDestinationMerged->group()->name(), QString("group3"));
+    QCOMPARE(entryDestinationMerged->username(), QStringLiteral("username"));
+    QCOMPARE(entryDestinationMerged->group()->name(), QStringLiteral("group3"));
     QCOMPARE(uuidBeforeSyncing, entryDestinationMerged->uuid());
     // default merge strategy is KeepNewer - therefore the older location is used!
     QCOMPARE(entryDestinationMerged->timeInfo().locationChanged(), sourceLocationChanged);
@@ -909,7 +909,7 @@ void TestMerge::testUpdateGroup()
     groupSourceInitial->setName("group2 renamed");
     groupSourceInitial->setNotes("updated notes");
     QUuid customIconId = QUuid::createUuid();
-    dbSource->metadata()->addCustomIcon(customIconId, QString("custom icon").toLocal8Bit());
+    dbSource->metadata()->addCustomIcon(customIconId, QStringLiteral("custom icon").toLocal8Bit());
     groupSourceInitial->setIcon(customIconId);
 
     QPointer<Entry> entrySourceInitial = dbSource->rootGroup()->findEntryByPath("entry1");
@@ -928,11 +928,11 @@ void TestMerge::testUpdateGroup()
     QPointer<Entry> entryDestinationMerged = dbDestination->rootGroup()->findEntryByPath("entry1 renamed");
     QVERIFY(entryDestinationMerged != nullptr);
     QVERIFY(entryDestinationMerged->group() != nullptr);
-    QCOMPARE(entryDestinationMerged->group()->name(), QString("group2 renamed"));
+    QCOMPARE(entryDestinationMerged->group()->name(), QStringLiteral("group2 renamed"));
     QCOMPARE(uuidBeforeSyncing, entryDestinationMerged->uuid());
 
     QPointer<Group> groupMerged = dbDestination->rootGroup()->findChildByName("group2 renamed");
-    QCOMPARE(groupMerged->notes(), QString("updated notes"));
+    QCOMPARE(groupMerged->notes(), QStringLiteral("updated notes"));
     QCOMPARE(groupMerged->iconUuid(), customIconId);
 }
 
@@ -1024,7 +1024,7 @@ void TestMerge::testMergeCustomIcons()
 
     QUuid customIconId = QUuid::createUuid();
 
-    dbSource->metadata()->addCustomIcon(customIconId, QString("custom icon").toLocal8Bit());
+    dbSource->metadata()->addCustomIcon(customIconId, QStringLiteral("custom icon").toLocal8Bit());
     // Sanity check.
     QVERIFY(dbSource->metadata()->hasCustomIcon(customIconId));
 
@@ -1120,11 +1120,11 @@ void TestMerge::testCustomData()
     QVERIFY(dbDestination->metadata()->customData()->contains("key2"));
     QVERIFY(dbDestination->metadata()->customData()->contains("Browser"));
     QVERIFY(!dbDestination->metadata()->customData()->contains("toBeDeleted"));
-    QCOMPARE(dbDestination->metadata()->customData()->value("key1"), QString("value1"));
-    QCOMPARE(dbDestination->metadata()->customData()->value("key2"), QString("value2"));
-    QCOMPARE(dbDestination->metadata()->customData()->value("Browser"), QString("n'8=3W@L^6d->d.]St_>]"));
+    QCOMPARE(dbDestination->metadata()->customData()->value("key1"), QStringLiteral("value1"));
+    QCOMPARE(dbDestination->metadata()->customData()->value("key2"), QStringLiteral("value2"));
+    QCOMPARE(dbDestination->metadata()->customData()->value("Browser"), QStringLiteral("n'8=3W@L^6d->d.]St_>]"));
     QCOMPARE(dbDestination->metadata()->customData()->value("key3"),
-             QString("newValue")); // Old value should be replaced
+             QStringLiteral("newValue")); // Old value should be replaced
 
     // Merging again should not do anything if the values are the same.
     m_clock->advanceSecond(1);
@@ -1144,7 +1144,7 @@ void TestMerge::testCustomData()
     QVERIFY(!dbDestination2->metadata()->customData()->contains("Browser"));
     QVERIFY(dbDestination2->metadata()->customData()->contains("notToBeDeleted"));
     QCOMPARE(dbDestination2->metadata()->customData()->value("key3"),
-             QString("oldValue")); // Old value should not be replaced
+             QStringLiteral("oldValue")); // Old value should not be replaced
 }
 
 void TestMerge::testDeletedEntry()

--- a/tests/TestModified.cpp
+++ b/tests/TestModified.cpp
@@ -307,13 +307,13 @@ void TestModified::testEntrySets()
     entry->setDefaultAutoTypeSequence(entry->defaultAutoTypeSequence());
     QTRY_COMPARE(spyModified.count(), spyCount);
 
-    entry->setForegroundColor(QString("#FF0000"));
+    entry->setForegroundColor(QStringLiteral("#FF0000"));
     ++spyCount;
     QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setForegroundColor(entry->foregroundColor());
     QTRY_COMPARE(spyModified.count(), spyCount);
 
-    entry->setBackgroundColor(QString("#FF0000"));
+    entry->setBackgroundColor(QStringLiteral("#FF0000"));
     ++spyCount;
     QTRY_COMPARE(spyModified.count(), spyCount);
     entry->setBackgroundColor(entry->backgroundColor());
@@ -370,7 +370,7 @@ void TestModified::testHistoryItems()
     entry->endUpdate();
     QCOMPARE(entry->historyItems().size(), ++historyItemsSize);
     auto* historyEntry = entry->historyItems().at(historyItemsSize - 1);
-    QCOMPARE(historyEntry->title(), QString("a"));
+    QCOMPARE(historyEntry->title(), QStringLiteral("a"));
     QCOMPARE(historyEntry->uuid(), entry->uuid());
     QCOMPARE(historyEntry->tags(), entry->tags());
     QCOMPARE(historyEntry->overrideUrl(), entry->overrideUrl());
@@ -382,7 +382,7 @@ void TestModified::testHistoryItems()
     entry->setTags("b");
     entry->endUpdate();
     QCOMPARE(entry->historyItems().size(), ++historyItemsSize);
-    QCOMPARE(entry->historyItems().at(historyItemsSize - 1)->tags(), QString("a"));
+    QCOMPARE(entry->historyItems().at(historyItemsSize - 1)->tags(), QStringLiteral("a"));
 
     entry->beginUpdate();
     entry->attachments()->set("test", QByteArray("value"));
@@ -429,7 +429,7 @@ void TestModified::testHistoryItems()
     QCOMPARE(entry2->historyItems().size(), 1);
 
     auto* historyEntry2 = entry2->historyItems().at(0);
-    QCOMPARE(historyEntry2->title(), QString("4"));
+    QCOMPARE(historyEntry2->title(), QStringLiteral("4"));
 
     db->metadata()->setHistoryMaxItems(-1);
 
@@ -463,7 +463,7 @@ void TestModified::testHistoryItems()
     QCOMPARE(entry2->historyItems().size(), 1);
 
     historyEntry2 = entry2->historyItems().at(0);
-    QCOMPARE(historyEntry2->title(), QString("7"));
+    QCOMPARE(historyEntry2->title(), QStringLiteral("7"));
 
     entry2->beginUpdate();
     entry2->setTitle("8");

--- a/tests/TestOpenSSHKey.cpp
+++ b/tests/TestOpenSSHKey.cpp
@@ -32,7 +32,7 @@ void TestOpenSSHKey::initTestCase()
 void TestOpenSSHKey::testParse()
 {
     // mixed line endings and missing ones are intentional, we only require 3 lines total
-    const QString keyString = QString("\r\n\r"
+    const QString keyString = QStringLiteral("\r\n\r"
                                       "-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW"
                                       "QyNTUxOQAAACDdlO5F2kF2WzedrBAHBi9wBHeISzXZ0IuIqrp0EzeazAAAAKjgCfj94An4"
@@ -47,11 +47,11 @@ void TestOpenSSHKey::testParse()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ssh-ed25519"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-parse@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:D1fVmA15YXzaJ5sdO9dXxo5coHL/pnNaIfCvokHzTA4"));
-    QCOMPARE(key.fingerprint(QCryptographicHash::Md5), QString("MD5:2d:e8:04:09:13:b4:2b:73:5e:87:43:cf:4e:6f:62:f1"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-ed25519"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-parse@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:D1fVmA15YXzaJ5sdO9dXxo5coHL/pnNaIfCvokHzTA4"));
+    QCOMPARE(key.fingerprint(QCryptographicHash::Md5), QStringLiteral("MD5:2d:e8:04:09:13:b4:2b:73:5e:87:43:cf:4e:6f:62:f1"));
 
     QByteArray publicKey, privateKey;
     BinaryStream publicStream(&publicKey), privateStream(&privateKey);
@@ -65,7 +65,7 @@ void TestOpenSSHKey::testParse()
 
 void TestOpenSSHKey::testParseDSA()
 {
-    const QString keyString = QString("-----BEGIN DSA PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN DSA PRIVATE KEY-----\n"
                                       "MIIBuwIBAAKBgQCudjbvSh8JxQOr2laCqZM1t4kNWBETVOXz5vgk9iw6Z5opB9/k\n"
                                       "g4nFc1PVq7fdAIc8W/5WCAjugKcxPb9PIHfcwY2fimmiPWFK68/eHKLoCuIn2wxB\n"
                                       "63ig2hAhx5U5aYG9QHkNCaT6VX7rc19nToSeZXlpja4x54/DaQaqOEWYsQIVAOer\n"
@@ -83,15 +83,15 @@ void TestOpenSSHKey::testParseDSA()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ssh-dss"));
-    QCOMPARE(key.comment(), QString(""));
-    QCOMPARE(key.fingerprint(), QString("SHA256:tbbNuLN1hja8JNASDTlLOZQsbTlJDzJlz/oAGK3sX18"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-dss"));
+    QCOMPARE(key.comment(), QString());
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:tbbNuLN1hja8JNASDTlLOZQsbTlJDzJlz/oAGK3sX18"));
 }
 
 void TestOpenSSHKey::testDecryptRSAAES128CBC()
 {
-    const QString keyString = QString("-----BEGIN RSA PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN RSA PRIVATE KEY-----\n"
                                       "Proc-Type: 4,ENCRYPTED\n"
                                       "DEK-Info: AES-128-CBC,804E4D214D1263FF94E3743FE799DBB4\n"
                                       "\n"
@@ -127,17 +127,17 @@ void TestOpenSSHKey::testDecryptRSAAES128CBC()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("AES-128-CBC"));
+    QCOMPARE(key.cipherName(), QStringLiteral("AES-128-CBC"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("correctpassphrase"));
-    QCOMPARE(key.type(), QString("ssh-rsa"));
-    QCOMPARE(key.comment(), QString(""));
-    QCOMPARE(key.fingerprint(), QString("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-rsa"));
+    QCOMPARE(key.comment(), QString());
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
 }
 
 void TestOpenSSHKey::testParseRSA()
 {
-    const QString keyString = QString("-----BEGIN RSA PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN RSA PRIVATE KEY-----\n"
                                       "MIIEpAIBAAKCAQEAsCHtJicDPWnvHSIKbnTZaJkIB9vgE0pmLdK580JUqBuonVbB\n"
                                       "y1QTy0ZQ7/TtqvLPgwPK88TR46OLO/QGCzo2+XxgJ85uy0xfuyUYRmSuw0drsErN\n"
                                       "mH8vU91lSBxsGDp9LtBbgHKoR23vMWZ34IxFRc55XphrIH48ijsMaL6bXBwF/3tD\n"
@@ -170,16 +170,16 @@ void TestOpenSSHKey::testParseRSA()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ssh-rsa"));
-    QCOMPARE(key.comment(), QString(""));
-    QCOMPARE(key.fingerprint(), QString("SHA256:DYdaZciYNxCejr+/8x+OKYxeTU1D5UsuIFUG4PWRFkk"));
-    QCOMPARE(key.fingerprint(QCryptographicHash::Md5), QString("MD5:c2:26:5b:3d:62:19:56:b0:c3:67:99:7a:a6:4c:66:06"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-rsa"));
+    QCOMPARE(key.comment(), QString());
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:DYdaZciYNxCejr+/8x+OKYxeTU1D5UsuIFUG4PWRFkk"));
+    QCOMPARE(key.fingerprint(QCryptographicHash::Md5), QStringLiteral("MD5:c2:26:5b:3d:62:19:56:b0:c3:67:99:7a:a6:4c:66:06"));
 }
 
 void TestOpenSSHKey::testParseRSACompare()
 {
-    const QString oldKeyString = QString("-----BEGIN RSA PRIVATE KEY-----\n"
+    const QString oldKeyString = QStringLiteral("-----BEGIN RSA PRIVATE KEY-----\n"
                                          "MIIEpAIBAAKCAQEAsCHtJicDPWnvHSIKbnTZaJkIB9vgE0pmLdK580JUqBuonVbB\n"
                                          "y1QTy0ZQ7/TtqvLPgwPK88TR46OLO/QGCzo2+XxgJ85uy0xfuyUYRmSuw0drsErN\n"
                                          "mH8vU91lSBxsGDp9LtBbgHKoR23vMWZ34IxFRc55XphrIH48ijsMaL6bXBwF/3tD\n"
@@ -207,7 +207,7 @@ void TestOpenSSHKey::testParseRSACompare()
                                          "tpbZA5KGKcvHtB5DDgT0MHwzBZnb4Q//Rhovzn+HXZPsJTTgHHy3NQ==\n"
                                          "-----END RSA PRIVATE KEY-----\n");
 
-    const QString newKeyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString newKeyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                          "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAABFwAAAAdzc2gtcn\n"
                                          "NhAAAAAwEAAQAAAQEAsCHtJicDPWnvHSIKbnTZaJkIB9vgE0pmLdK580JUqBuonVbBy1QT\n"
                                          "y0ZQ7/TtqvLPgwPK88TR46OLO/QGCzo2+XxgJ85uy0xfuyUYRmSuw0drsErNmH8vU91lSB\n"
@@ -259,7 +259,7 @@ void TestOpenSSHKey::testParseRSACompare()
 
 void TestOpenSSHKey::testParseECDSA256()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAaAAAABNlY2RzYS\n"
                                       "1zaGEyLW5pc3RwMjU2AAAACG5pc3RwMjU2AAAAQQT461x/QlaUUc+H7BxfI5CFXvcMGXA7\n"
                                       "Wp/U/2sfTMuKWUHumBJyjGM4/wJ9V1EldWp3e4MqH2oztQBDoXNlUsn9AAAAwP2/iHH9v4\n"
@@ -274,16 +274,16 @@ void TestOpenSSHKey::testParseECDSA256()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp256"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa256@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:nwwovZmQbBeiR3GZRpK4OWHgCUE7E0wFtCN7Ng7eX5g"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ecdsa-sha2-nistp256"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-ecdsa256@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:nwwovZmQbBeiR3GZRpK4OWHgCUE7E0wFtCN7Ng7eX5g"));
     QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseECDSA384()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAiAAAABNlY2RzYS\n"
                                       "1zaGEyLW5pc3RwMzg0AAAACG5pc3RwMzg0AAAAYQSLw/MlwQSW/y+mD9KpoXkoHLK88uKJ\n"
                                       "hD8HLTNpJ+fdIP24Z6w4vJeddJo/dmsl945UwMzIaHA5DPQmUyAIAcId8wTZRF9xqRpaQI\n"
@@ -300,16 +300,16 @@ void TestOpenSSHKey::testParseECDSA384()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp384"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa384@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:B5tLMG976BZ6nyi/oRUmKaTJcaEaFagEjBfOAgru0OY"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ecdsa-sha2-nistp384"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-ecdsa384@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:B5tLMG976BZ6nyi/oRUmKaTJcaEaFagEjBfOAgru0OY"));
     QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseECDSA521()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAArAAAABNlY2RzYS\n"
                                       "1zaGEyLW5pc3RwNTIxAAAACG5pc3RwNTIxAAAAhQQBIxaAOfN2yDEHakGVzGfTTzhqwLYf\n"
                                       "7lcOgVpSSbjsDylAV9l+Pd0yBNmf/WqLWN9nzmDaSf2KqGm1HjSKgF+kt60BOyMqNIY1g/\n"
@@ -327,16 +327,16 @@ void TestOpenSSHKey::testParseECDSA521()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("ecdsa-sha2-nistp521"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa521@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:m3LtA9MtZW8FN0R3vwA0AAI+YtegbggGCy3EGKWya+s"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("ecdsa-sha2-nistp521"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-ecdsa521@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:m3LtA9MtZW8FN0R3vwA0AAI+YtegbggGCy3EGKWya+s"));
     QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testDecryptOpenSSHAES256CBC()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jYmMAAAAGYmNyeXB0AAAAGAAAABD2A0agtd\n"
                                       "oGtJiI9JvIxYbTAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIDPvDXmi0w1rdMoX\n"
                                       "fOeyZ0Q/v+wqq/tPFgJwxnW5ADtfAAAAsC3UPsf035hrF5SgZ48p55iDFPiyGfZC/C3vQx\n"
@@ -350,11 +350,11 @@ void TestOpenSSHKey::testDecryptOpenSSHAES256CBC()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("aes256-cbc"));
+    QCOMPARE(key.cipherName(), QStringLiteral("aes256-cbc"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("correctpassphrase"));
-    QCOMPARE(key.type(), QString("ssh-ed25519"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-aes256cbc@keepassxc"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-ed25519"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-aes256cbc@keepassxc"));
 
     QByteArray publicKey, privateKey;
     BinaryStream publicStream(&publicKey), privateStream(&privateKey);
@@ -368,7 +368,7 @@ void TestOpenSSHKey::testDecryptOpenSSHAES256CBC()
 
 void TestOpenSSHKey::testDecryptRSAAES256CBC()
 {
-    const QString keyString = QString("-----BEGIN RSA PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN RSA PRIVATE KEY-----\n"
                                       "Proc-Type: 4,ENCRYPTED\n"
                                       "DEK-Info: AES-256-CBC,D51E3F558B621BD9384627762CBD16AC\n"
                                       "\n"
@@ -404,17 +404,17 @@ void TestOpenSSHKey::testDecryptRSAAES256CBC()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("AES-256-CBC"));
+    QCOMPARE(key.cipherName(), QStringLiteral("AES-256-CBC"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("correctpassphrase"));
-    QCOMPARE(key.type(), QString("ssh-rsa"));
-    QCOMPARE(key.comment(), QString(""));
-    QCOMPARE(key.fingerprint(), QString("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-rsa"));
+    QCOMPARE(key.comment(), QString());
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
 }
 
 void TestOpenSSHKey::testDecryptOpenSSHAES256CTR()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABAMhIAypt\n"
                                       "WP4tZJBmMwq0tTAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIErNsS8ROy43XoWC\n"
                                       "nO9Sn2lEFBJYcDVtRPM1t6WB7W7OAAAAsFKXMOlPILoTmMj2JmcqzjaYAhaCezx18HDp76\n"
@@ -428,11 +428,11 @@ void TestOpenSSHKey::testDecryptOpenSSHAES256CTR()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("aes256-ctr"));
+    QCOMPARE(key.cipherName(), QStringLiteral("aes256-ctr"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("correctpassphrase"));
-    QCOMPARE(key.type(), QString("ssh-ed25519"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-aes256ctr@keepassxc"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-ed25519"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-aes256ctr@keepassxc"));
 
     QByteArray publicKey, privateKey;
     BinaryStream publicStream(&publicKey), privateStream(&privateKey);
@@ -446,7 +446,7 @@ void TestOpenSSHKey::testDecryptOpenSSHAES256CTR()
 
 void TestOpenSSHKey::testDecryptRSAAES256CTR()
 {
-    const QString keyString = QString("-----BEGIN RSA PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN RSA PRIVATE KEY-----\n"
                                       "Proc-Type: 4,ENCRYPTED\n"
                                       "DEK-Info: AES-256-CTR,192421854316290DFA8F469A1E8CB9BB\n"
                                       "\n"
@@ -482,17 +482,17 @@ void TestOpenSSHKey::testDecryptRSAAES256CTR()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("AES-256-CTR"));
+    QCOMPARE(key.cipherName(), QStringLiteral("AES-256-CTR"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("correctpassphrase"));
-    QCOMPARE(key.type(), QString("ssh-rsa"));
-    QCOMPARE(key.comment(), QString(""));
-    QCOMPARE(key.fingerprint(), QString("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-rsa"));
+    QCOMPARE(key.comment(), QString());
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:1Hsebt2WWnmc72FERsUOgvaajIGHkrMONxXylcmk87U"));
 }
 
 void TestOpenSSHKey::testDecryptUTF8()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAACmFlczI1Ni1jdHIAAAAGYmNyeXB0AAAAGAAAABDtSl4OvT\n"
                                       "H/wHay2dvjOnpIAAAAEAAAAAEAAAAzAAAAC3NzaC1lZDI1NTE5AAAAIIhrBrn6rb+d3GwF\n"
                                       "ifpJ6gYut95lXvwypiQmu9ZpA8H9AAAAsD85Gpn2mbVEWq3ygx11wBnN5mUQXnMuP48rLv\n"
@@ -506,17 +506,17 @@ void TestOpenSSHKey::testDecryptUTF8()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(key.encrypted());
-    QCOMPARE(key.cipherName(), QString("aes256-ctr"));
+    QCOMPARE(key.cipherName(), QStringLiteral("aes256-ctr"));
     QVERIFY(!key.openKey("incorrectpassphrase"));
     QVERIFY(key.openKey("äåéëþüúíóö"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:EfUXwvH4rOoys+AlbznCqjMwzIVW8KuhoWu9uT03FYA"));
-    QCOMPARE(key.type(), QString("ssh-ed25519"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-utf8@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:EfUXwvH4rOoys+AlbznCqjMwzIVW8KuhoWu9uT03FYA"));
+    QCOMPARE(key.type(), QStringLiteral("ssh-ed25519"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-utf8@keepassxc"));
 }
 
 void TestOpenSSHKey::testParseECDSASecurityKey()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAfwAAACJzay1lY2\n"
                                       "RzYS1zaGEyLW5pc3RwMjU2QG9wZW5zc2guY29tAAAACG5pc3RwMjU2AAAAQQQ2Pr1d6zUa\n"
                                       "qcmYgjTGQUF9QPkFEo2Q7aQbvyL/0KL9FObuOfzqxs8mDqswXEsXR4g5L6P7vEe6nPqzSW\n"
@@ -533,16 +533,16 @@ void TestOpenSSHKey::testParseECDSASecurityKey()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("sk-ecdsa-sha2-nistp256@openssh.com"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-ecdsa-sk@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:ctOtAsPMqbtumGI41o2oeWfGDah4m1ACILRj+x0gx0E"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("sk-ecdsa-sha2-nistp256@openssh.com"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-ecdsa-sk@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:ctOtAsPMqbtumGI41o2oeWfGDah4m1ACILRj+x0gx0E"));
     QCOMPARE(keyString, key.privateKey());
 }
 
 void TestOpenSSHKey::testParseED25519SecurityKey()
 {
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAASgAAABpzay1zc2\n"
                                       "gtZWQyNTUxOUBvcGVuc3NoLmNvbQAAACCSIfzsjUBlhsVBfHHlQCUpj1Yt+404RetvfTnd\n"
                                       "DJIIqgAAAARzc2g6AAABCN1MUOzdTFDsAAAAGnNrLXNzaC1lZDI1NTE5QG9wZW5zc2guY2\n"
@@ -558,9 +558,9 @@ void TestOpenSSHKey::testParseED25519SecurityKey()
     OpenSSHKey key;
     QVERIFY(key.parsePKCS1PEM(keyData));
     QVERIFY(!key.encrypted());
-    QCOMPARE(key.cipherName(), QString("none"));
-    QCOMPARE(key.type(), QString("sk-ssh-ed25519@openssh.com"));
-    QCOMPARE(key.comment(), QString("opensshkey-test-ed25519-sk@keepassxc"));
-    QCOMPARE(key.fingerprint(), QString("SHA256:PGtS5WvbnYmNqFIeRbzO6cVP9GLh8eEzENgkHp02XIA"));
+    QCOMPARE(key.cipherName(), QStringLiteral("none"));
+    QCOMPARE(key.type(), QStringLiteral("sk-ssh-ed25519@openssh.com"));
+    QCOMPARE(key.comment(), QStringLiteral("opensshkey-test-ed25519-sk@keepassxc"));
+    QCOMPARE(key.fingerprint(), QStringLiteral("SHA256:PGtS5WvbnYmNqFIeRbzO6cVP9GLh8eEzENgkHp02XIA"));
     QCOMPARE(keyString, key.privateKey());
 }

--- a/tests/TestPasskeys.cpp
+++ b/tests/TestPasskeys.cpp
@@ -133,7 +133,7 @@ void TestPasskeys::testBase64WithHexStrings()
 
     auto base64FromArray = browserMessageBuilder()->getBase64FromArray(reinterpret_cast<const char*>(buf), bufSize);
     QCOMPARE(base64FromArray,
-             QString("H40eHY5JBe_yVLvKKDYP38kAbG3RaM_voFnQdYZCKgwfQqP43VjxpAY3tmG686KiUdw3PF3Pqt446uMtc6-Ktg"));
+             QStringLiteral("H40eHY5JBe_yVLvKKDYP38kAbG3RaM_voFnQdYZCKgwfQqP43VjxpAY3tmG686KiUdw3PF3Pqt446uMtc6-Ktg"));
 
     auto arrayFromBase64 = browserMessageBuilder()->getArrayFromBase64(base64FromArray);
     QCOMPARE(arrayFromBase64.size(), bufSize);
@@ -160,9 +160,9 @@ void TestPasskeys::testDecodeResponseData()
     auto clientDataByteArray = browserMessageBuilder()->getArrayFromBase64(clientDataJson);
     auto clientDataJsonObject = browserMessageBuilder()->getJsonObject(clientDataByteArray);
     QCOMPARE(clientDataJsonObject["challenge"],
-             QString("lVeHzVxWsr8MQxMkZF0ti6FXhdgMljqKzgA-q_zk2Mnii3eJ47VF97sqUoYktVC85WAZ1uIASm-a_lDFZwsLfw"));
-    QCOMPARE(clientDataJsonObject["origin"], QString("https://webauthn.io"));
-    QCOMPARE(clientDataJsonObject["type"], QString("webauthn.create"));
+             QStringLiteral("lVeHzVxWsr8MQxMkZF0ti6FXhdgMljqKzgA-q_zk2Mnii3eJ47VF97sqUoYktVC85WAZ1uIASm-a_lDFZwsLfw"));
+    QCOMPARE(clientDataJsonObject["origin"], QStringLiteral("https://webauthn.io"));
+    QCOMPARE(clientDataJsonObject["type"], QStringLiteral("webauthn.create"));
 
     // Parse attestationObject (CBOR decoding needed)
     BrowserCbor browserCbor;
@@ -181,15 +181,15 @@ void TestPasskeys::testDecodeResponseData()
 
     // The attestationObject should include the same ID after decoding with the response root
     QCOMPARE(credentialData["credentialId"].toString(), publicKeyCredential["id"].toString());
-    QCOMPARE(credentialData["aaguid"].toString(), QString("_bFBsl2ERD6KNUaYwgWlAg"));
-    QCOMPARE(authData["rpIdHash"].toString(), QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
+    QCOMPARE(credentialData["aaguid"].toString(), QStringLiteral("_bFBsl2ERD6KNUaYwgWlAg"));
+    QCOMPARE(authData["rpIdHash"].toString(), QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
     QCOMPARE(flags["AT"], true);
     QCOMPARE(flags["UP"], true);
     QCOMPARE(publicKey["1"], 2);
     QCOMPARE(publicKey["3"], -7);
     QCOMPARE(publicKey["-1"], 1);
-    QCOMPARE(publicKey["-2"], QString("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0"));
-    QCOMPARE(publicKey["-3"], QString("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M"));
+    QCOMPARE(publicKey["-2"], QStringLiteral("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0"));
+    QCOMPARE(publicKey["-3"], QStringLiteral("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M"));
 }
 
 void TestPasskeys::testLoadingECPrivateKeyFromPem()
@@ -199,7 +199,7 @@ void TestPasskeys::testLoadingECPrivateKeyFromPem()
 #endif
     const auto publicKeyCredentialRequestOptions =
         browserMessageBuilder()->getJsonObject(PublicKeyCredentialRequestOptions.toUtf8());
-    const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
+    const auto privateKeyPem = QStringLiteral("-----BEGIN PRIVATE KEY-----"
                                        "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg5DX2R6I37nMSZqCp"
                                        "XfHlE3UeitkGGE03FqGsdfxIBoOhRANCAAQG7K80W2KRYW0ZWQOmUCrKMcSVqGnl"
                                        "8Ifl1LgyzQiF3eLuf+kPDukdB4NKAwnbQiSxC9Ml/xgy4VOZtx1CBOeD"
@@ -215,12 +215,12 @@ void TestPasskeys::testLoadingECPrivateKeyFromPem()
     const auto signature = browserPasskeys()->buildSignature(authenticatorData, clientData, privateKeyPem);
     QCOMPARE(
         browserMessageBuilder()->getBase64FromArray(signature),
-        QString("MEYCIQCpbDaYJ4b2ofqWBxfRNbH3XCpsyao7Iui5lVuJRU9HIQIhAPl5moNZgJu5zmurkKK_P900Ct6wd3ahVIqCEqTeeRdE"));
+        QStringLiteral("MEYCIQCpbDaYJ4b2ofqWBxfRNbH3XCpsyao7Iui5lVuJRU9HIQIhAPl5moNZgJu5zmurkKK_P900Ct6wd3ahVIqCEqTeeRdE"));
 }
 
 void TestPasskeys::testLoadingRSAPrivateKeyFromPem()
 {
-    const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
+    const auto privateKeyPem = QStringLiteral("-----BEGIN PRIVATE KEY-----"
                                        "MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQC5OHjBHQaRfxxX\n4WHRmqq7e7JgT"
                                        "FRs1bd4dIOFAOZnhNE3vAg2IF5VurmeB+9ye9xh7frw8ubrL0cv\nsBWiJfN5CY3SYGRLbGTtBC0fZ6"
                                        "OhhhjwvVM1GW6nVeRU66atzuo4NBfYXJWIYECd\npRBU4+xsDL4vJnn1mj05+v/Tqp6Uo1HrEPx9+Dc"
@@ -255,7 +255,7 @@ void TestPasskeys::testLoadingRSAPrivateKeyFromPem()
     const auto signature = browserPasskeys()->buildSignature(authenticatorData, clientData, privateKeyPem);
     QCOMPARE(
         browserMessageBuilder()->getBase64FromArray(signature),
-        QString("MOGw6KrerCgPf2mPig7FOTFIUDXYAU1v2uZj89_NgQTg2UddWnAB3JId3pa4zXghj8CkjjadVOI_LvweJGCEpmPQnRby71yFXnja6j"
+        QStringLiteral("MOGw6KrerCgPf2mPig7FOTFIUDXYAU1v2uZj89_NgQTg2UddWnAB3JId3pa4zXghj8CkjjadVOI_LvweJGCEpmPQnRby71yFXnja6j"
                 "Y3woX2b2klG2fB2alGZHHrVg6yVEmnAii4kYSdmoWxI7SmzLftoZfCJNFPFHujx2Pbr-6dIB02sZhtncetT0cpyWobtj9r7C5dIGfm"
                 "J5n-LccP-F9gXGqtbN605VrIkC2WNztjdk3dAt5FGM_dlIwSe-vP1dKfIuNqAEbgr2IVZAUFn_ZfzUo-XbXTysksuz9JZfEopJBiUi"
                 "9tjQDNvrYQFqB6wDPqkZAomkbRCohUb3TzCg"));
@@ -264,17 +264,17 @@ void TestPasskeys::testLoadingRSAPrivateKeyFromPem()
 void TestPasskeys::testCreatingAttestationObjectWithEC()
 {
     // Predefined values for a desired outcome
-    const auto id = QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
-    const auto predefinedFirst = QString("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0");
-    const auto predefinedSecond = QString("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M");
+    const auto id = QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
+    const auto predefinedFirst = QStringLiteral("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0");
+    const auto predefinedSecond = QStringLiteral("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M");
 
     const auto publicKeyCredentialOptions = browserMessageBuilder()->getJsonObject(PublicKeyCredentialOptions.toUtf8());
     QJsonObject credentialCreationOptions;
     browserPasskeysClient()->getCredentialCreationOptions(
-        publicKeyCredentialOptions, QString("https://webauthn.io"), &credentialCreationOptions);
+        publicKeyCredentialOptions, QStringLiteral("https://webauthn.io"), &credentialCreationOptions);
 
-    auto rpIdHash = browserMessageBuilder()->getSha256HashAsBase64(QString("webauthn.io"));
-    QCOMPARE(rpIdHash, QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
+    auto rpIdHash = browserMessageBuilder()->getSha256HashAsBase64(QStringLiteral("webauthn.io"));
+    QCOMPARE(rpIdHash, QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
 
     TestingVariables testingVariables = {id, predefinedFirst, predefinedSecond};
     const auto alg = browserPasskeys()->getAlgorithmFromPublicKey(credentialCreationOptions);
@@ -309,8 +309,8 @@ void TestPasskeys::testCreatingAttestationObjectWithEC()
     auto publicKey = credentialData["publicKey"].toObject();
 
     // The attestationObject should include the same ID after decoding with the response root
-    QCOMPARE(credentialData["credentialId"].toString(), QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
-    QCOMPARE(authData["rpIdHash"].toString(), QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
+    QCOMPARE(credentialData["credentialId"].toString(), QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
+    QCOMPARE(authData["rpIdHash"].toString(), QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
     QCOMPARE(flags["AT"], true);
     QCOMPARE(flags["UP"], true);
     QCOMPARE(publicKey["1"], WebAuthnCoseKeyType::EC2);
@@ -323,13 +323,13 @@ void TestPasskeys::testCreatingAttestationObjectWithEC()
 void TestPasskeys::testCreatingAttestationObjectWithRSA()
 {
     // Predefined values for a desired outcome
-    const auto id = QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
-    const auto predefinedModulus = QString("vUhOZnyn8yn7U-nuHlsXZ6WDWLuYvevWWnwtoHxDEQq27vlp7yAfeVvAPkcvhxRcwoCEUespoa5"
+    const auto id = QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
+    const auto predefinedModulus = QStringLiteral("vUhOZnyn8yn7U-nuHlsXZ6WDWLuYvevWWnwtoHxDEQq27vlp7yAfeVvAPkcvhxRcwoCEUespoa5"
                                            "5IDbkpp2Ypd6b15KbB4C-_4gM4r2FK9gfXghLPAXsMhstYv4keNFb4ghdlY5oUU3JCqUSMyOpmd"
                                            "HeX-RikLL0wgGv_tLT2DaDiWeyQCAtiDblr6COuTAU2kTpLc3Bn35geV9Iqw4iT8DwBQ-f8vjnI"
                                            "EDANXKUiRPojfy1q7WwEl-zMv6Ke2jFHxf68u82BSy3u9DOQaa24FAHoCm8Yd0n5IazMyoxyttl"
                                            "tRt8un8myVOGxcXMiR9_kQb9pu1RRLQMQLd-icE1Qw");
-    const auto predefinedExponent = QString("AQAB");
+    const auto predefinedExponent = QStringLiteral("AQAB");
 
     // Force algorithm to RSA
     QJsonArray pubKeyCredParams;
@@ -338,11 +338,11 @@ void TestPasskeys::testCreatingAttestationObjectWithRSA()
     const auto publicKeyCredentialOptions = browserMessageBuilder()->getJsonObject(PublicKeyCredentialOptions.toUtf8());
     QJsonObject credentialCreationOptions;
     browserPasskeysClient()->getCredentialCreationOptions(
-        publicKeyCredentialOptions, QString("https://webauthn.io"), &credentialCreationOptions);
+        publicKeyCredentialOptions, QStringLiteral("https://webauthn.io"), &credentialCreationOptions);
     credentialCreationOptions["credTypesAndPubKeyAlgs"] = pubKeyCredParams;
 
-    auto rpIdHash = browserMessageBuilder()->getSha256HashAsBase64(QString("webauthn.io"));
-    QCOMPARE(rpIdHash, QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
+    auto rpIdHash = browserMessageBuilder()->getSha256HashAsBase64(QStringLiteral("webauthn.io"));
+    QCOMPARE(rpIdHash, QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
 
     TestingVariables testingVariables = {id, predefinedModulus, predefinedExponent};
     const auto alg = browserPasskeys()->getAlgorithmFromPublicKey(credentialCreationOptions);
@@ -366,8 +366,8 @@ void TestPasskeys::testCreatingAttestationObjectWithRSA()
     auto publicKey = credentialData["publicKey"].toObject();
 
     // The attestationObject should include the same ID after decoding with the response root
-    QCOMPARE(credentialData["credentialId"].toString(), QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
-    QCOMPARE(authData["rpIdHash"].toString(), QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
+    QCOMPARE(credentialData["credentialId"].toString(), QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
+    QCOMPARE(authData["rpIdHash"].toString(), QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvA"));
     QCOMPARE(flags["AT"], true);
     QCOMPARE(flags["UP"], true);
     QCOMPARE(publicKey["1"], WebAuthnCoseKeyType::RSA);
@@ -379,10 +379,10 @@ void TestPasskeys::testCreatingAttestationObjectWithRSA()
 void TestPasskeys::testRegister()
 {
     // Predefined values for a desired outcome
-    const auto predefinedId = QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
-    const auto predefinedX = QString("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0");
-    const auto predefinedY = QString("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M");
-    const auto origin = QString("https://webauthn.io");
+    const auto predefinedId = QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
+    const auto predefinedX = QStringLiteral("BuyvNFtikWFtGVkDplAqyjHElahp5fCH5dS4Ms0Ihd0");
+    const auto predefinedY = QStringLiteral("4u5_6Q8O6R0Hg0oDCdtCJLEL0yX_GDLhU5m3HUIE54M");
+    const auto origin = QStringLiteral("https://webauthn.io");
     const auto testDataPublicKey = browserMessageBuilder()->getJsonObject(PublicKeyCredential.toUtf8());
     const auto testDataResponse = testDataPublicKey["response"];
     const auto publicKeyCredentialOptions = browserMessageBuilder()->getJsonObject(PublicKeyCredentialOptions.toUtf8());
@@ -395,9 +395,9 @@ void TestPasskeys::testRegister()
     TestingVariables testingVariables = {predefinedId, predefinedX, predefinedY};
     auto result = browserPasskeys()->buildRegisterPublicKeyCredential(credentialCreationOptions, testingVariables);
     auto publicKeyCredential = result.response;
-    QCOMPARE(publicKeyCredential["type"], QString("public-key"));
-    QCOMPARE(publicKeyCredential["authenticatorAttachment"], QString("platform"));
-    QCOMPARE(publicKeyCredential["id"], QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
+    QCOMPARE(publicKeyCredential["type"], QStringLiteral("public-key"));
+    QCOMPARE(publicKeyCredential["authenticatorAttachment"], QStringLiteral("platform"));
+    QCOMPARE(publicKeyCredential["id"], QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8"));
 
     auto response = publicKeyCredential["response"].toObject();
     auto attestationObject = response["attestationObject"].toString();
@@ -408,9 +408,9 @@ void TestPasskeys::testRegister()
     auto clientDataByteArray = browserMessageBuilder()->getArrayFromBase64(clientDataJson);
     auto clientDataJsonObject = browserMessageBuilder()->getJsonObject(clientDataByteArray);
     QCOMPARE(clientDataJsonObject["challenge"],
-             QString("lVeHzVxWsr8MQxMkZF0ti6FXhdgMljqKzgA-q_zk2Mnii3eJ47VF97sqUoYktVC85WAZ1uIASm-a_lDFZwsLfw"));
+             QStringLiteral("lVeHzVxWsr8MQxMkZF0ti6FXhdgMljqKzgA-q_zk2Mnii3eJ47VF97sqUoYktVC85WAZ1uIASm-a_lDFZwsLfw"));
     QCOMPARE(clientDataJsonObject["origin"], origin);
-    QCOMPARE(clientDataJsonObject["type"], QString("webauthn.create"));
+    QCOMPARE(clientDataJsonObject["type"], QStringLiteral("webauthn.create"));
 }
 
 void TestPasskeys::testGet()
@@ -418,13 +418,13 @@ void TestPasskeys::testGet()
 #if BOTAN_VERSION_CODE < BOTAN_VERSION_CODE_FOR(2, 14, 0)
     QSKIP("ECDSA Signature is broken on Botan < 2.14.0");
 #endif
-    const auto privateKeyPem = QString("-----BEGIN PRIVATE KEY-----"
+    const auto privateKeyPem = QStringLiteral("-----BEGIN PRIVATE KEY-----"
                                        "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQg5DX2R6I37nMSZqCp"
                                        "XfHlE3UeitkGGE03FqGsdfxIBoOhRANCAAQG7K80W2KRYW0ZWQOmUCrKMcSVqGnl"
                                        "8Ifl1LgyzQiF3eLuf+kPDukdB4NKAwnbQiSxC9Ml/xgy4VOZtx1CBOeD"
                                        "-----END PRIVATE KEY-----");
-    const auto origin = QString("https://webauthn.io");
-    const auto id = QString("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
+    const auto origin = QStringLiteral("https://webauthn.io");
+    const auto id = QStringLiteral("yrzFJ5lwcpTwYMOdXSmxF5b5cYQlqBMzbbU_d-oFLO8");
     const auto publicKeyCredentialRequestOptions =
         browserMessageBuilder()->getJsonObject(PublicKeyCredentialRequestOptions.toUtf8());
 
@@ -438,14 +438,14 @@ void TestPasskeys::testGet()
     QCOMPARE(publicKeyCredential["id"].toString(), id);
 
     auto response = publicKeyCredential["response"].toObject();
-    QCOMPARE(response["authenticatorData"].toString(), QString("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvAFAAAAAA"));
+    QCOMPARE(response["authenticatorData"].toString(), QStringLiteral("dKbqkhPJnC90siSSsyDPQCYqlMGpUKA5fyklC2CEHvAFAAAAAA"));
     QCOMPARE(response["clientDataJSON"].toString(),
-             QString("eyJjaGFsbGVuZ2UiOiI5ejM2dlRmUVRMOTVMZjdXblpneXRlN29oR2VGLVhSaUx4a0wtTHVHVTF6b3BSbU1JVUExTFZ3ekdwe"
+             QStringLiteral("eyJjaGFsbGVuZ2UiOiI5ejM2dlRmUVRMOTVMZjdXblpneXRlN29oR2VGLVhSaUx4a0wtTHVHVTF6b3BSbU1JVUExTFZ3ekdwe"
                      "UltMWZPQm4xUW5SYTBRSDI3QURBYUpHSHlzUSIsImNyb3NzT3JpZ2luIjpmYWxzZSwib3JpZ2luIjoiaHR0cHM6Ly93ZWJhdX"
                      "Robi5pbyIsInR5cGUiOiJ3ZWJhdXRobi5nZXQifQ"));
     QCOMPARE(
         response["signature"].toString(),
-        QString("MEUCIHFv0lOOGGloi_XoH5s3QDSs__8yAp9ZTMEjNiacMpOxAiEA04LAfO6TE7j12XNxd3zHQpn4kZN82jQFPntPiPBSD5c"));
+        QStringLiteral("MEUCIHFv0lOOGGloi_XoH5s3QDSs__8yAp9ZTMEjNiacMpOxAiEA04LAfO6TE7j12XNxd3zHQpn4kZN82jQFPntPiPBSD5c"));
 
     auto clientDataJson = response["clientDataJSON"].toString();
     auto clientDataByteArray = browserMessageBuilder()->getArrayFromBase64(clientDataJson);
@@ -529,12 +529,12 @@ void TestPasskeys::testEntry()
     entry->setGroup(root);
 
     browserService()->addPasskeyToEntry(entry,
-                                        QString("example.com"),
-                                        QString("example.com"),
-                                        QString("username"),
-                                        QString("userId"),
-                                        QString("userHandle"),
-                                        QString("privateKey"));
+                                        QStringLiteral("example.com"),
+                                        QStringLiteral("example.com"),
+                                        QStringLiteral("username"),
+                                        QStringLiteral("userId"),
+                                        QStringLiteral("userHandle"),
+                                        QStringLiteral("privateKey"));
 
     QVERIFY(entry->hasPasskey());
 }
@@ -553,81 +553,81 @@ void TestPasskeys::testIsDomain()
 // List from https://html.spec.whatwg.org/multipage/browsers.html#is-a-registrable-domain-suffix-of-or-is-equal-to
 void TestPasskeys::testRegistrableDomainSuffix()
 {
-    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QString("example.com"), QString("example.com")));
-    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QString("example.com"), QString("example.com.")));
-    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QString("example.com."), QString("example.com")));
-    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QString("example.com"), QString("www.example.com")));
-    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QString("com"), QString("example.com")));
-    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QString("example"), QString("example")));
+    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example.com"), QStringLiteral("example.com")));
+    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example.com"), QStringLiteral("example.com.")));
+    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example.com."), QStringLiteral("example.com")));
+    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example.com"), QStringLiteral("www.example.com")));
+    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("com"), QStringLiteral("example.com")));
+    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example"), QStringLiteral("example")));
     QVERIFY(
-        !passkeyUtils()->isRegistrableDomainSuffix(QString("s3.amazonaws.com"), QString("example.s3.amazonaws.com")));
-    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QString("example.compute.amazonaws.com"),
-                                                       QString("www.example.compute.amazonaws.com")));
-    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QString("amazonaws.com"),
-                                                       QString("www.example.compute.amazonaws.com")));
-    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QString("amazonaws.com"), QString("test.amazonaws.com")));
+        !passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("s3.amazonaws.com"), QStringLiteral("example.s3.amazonaws.com")));
+    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("example.compute.amazonaws.com"),
+                                                       QStringLiteral("www.example.compute.amazonaws.com")));
+    QVERIFY(!passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("amazonaws.com"),
+                                                       QStringLiteral("www.example.compute.amazonaws.com")));
+    QVERIFY(passkeyUtils()->isRegistrableDomainSuffix(QStringLiteral("amazonaws.com"), QStringLiteral("test.amazonaws.com")));
 }
 
 void TestPasskeys::testRpIdValidation()
 {
     QString result;
-    auto allowedIdentical = passkeyUtils()->validateRpId(QString("example.com"), QString("example.com"), &result);
-    QCOMPARE(result, QString("example.com"));
+    auto allowedIdentical = passkeyUtils()->validateRpId(QStringLiteral("example.com"), QStringLiteral("example.com"), &result);
+    QCOMPARE(result, QStringLiteral("example.com"));
     QVERIFY(allowedIdentical == 0);
 
     result.clear();
-    auto allowedSubdomain = passkeyUtils()->validateRpId(QString("example.com"), QString("www.example.com"), &result);
-    QCOMPARE(result, QString("example.com"));
+    auto allowedSubdomain = passkeyUtils()->validateRpId(QStringLiteral("example.com"), QStringLiteral("www.example.com"), &result);
+    QCOMPARE(result, QStringLiteral("example.com"));
     QVERIFY(allowedSubdomain == 0);
 
     result.clear();
-    auto emptyRpId = passkeyUtils()->validateRpId({}, QString("example.com"), &result);
-    QCOMPARE(result, QString(""));
+    auto emptyRpId = passkeyUtils()->validateRpId({}, QStringLiteral("example.com"), &result);
+    QCOMPARE(result, QString());
     QVERIFY(emptyRpId == ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto ipRpId = passkeyUtils()->validateRpId(QString("127.0.0.1"), QString("example.com"), &result);
-    QCOMPARE(result, QString(""));
+    auto ipRpId = passkeyUtils()->validateRpId(QStringLiteral("127.0.0.1"), QStringLiteral("example.com"), &result);
+    QCOMPARE(result, QString());
     QVERIFY(ipRpId == ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto emptyOrigin = passkeyUtils()->validateRpId(QString("example.com"), QString(""), &result);
+    auto emptyOrigin = passkeyUtils()->validateRpId(QStringLiteral("example.com"), QString(), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(emptyOrigin, ERROR_PASSKEYS_ORIGIN_NOT_ALLOWED);
 
     result.clear();
-    auto ipOrigin = passkeyUtils()->validateRpId(QString("example.com"), QString("127.0.0.1"), &result);
+    auto ipOrigin = passkeyUtils()->validateRpId(QStringLiteral("example.com"), QStringLiteral("127.0.0.1"), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(ipOrigin, ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto invalidRpId = passkeyUtils()->validateRpId(QString(".com"), QString("example.com"), &result);
+    auto invalidRpId = passkeyUtils()->validateRpId(QStringLiteral(".com"), QStringLiteral("example.com"), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(invalidRpId, ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto malformedOrigin = passkeyUtils()->validateRpId(QString("example.com."), QString("example.com."), &result);
+    auto malformedOrigin = passkeyUtils()->validateRpId(QStringLiteral("example.com."), QStringLiteral("example.com."), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(malformedOrigin, ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto malformed = passkeyUtils()->validateRpId(QString("...com."), QString("example...com"), &result);
+    auto malformed = passkeyUtils()->validateRpId(QStringLiteral("...com."), QStringLiteral("example...com"), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(malformed, ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 
     result.clear();
-    auto differentDomain = passkeyUtils()->validateRpId(QString("another.com"), QString("example.com"), &result);
+    auto differentDomain = passkeyUtils()->validateRpId(QStringLiteral("another.com"), QStringLiteral("example.com"), &result);
     QVERIFY(result.isEmpty());
     QCOMPARE(differentDomain, ERROR_PASSKEYS_DOMAIN_RPID_MISMATCH);
 }
 
 void TestPasskeys::testParseAttestation()
 {
-    QVERIFY(passkeyUtils()->parseAttestation(QString("")) == QString("none"));
-    QVERIFY(passkeyUtils()->parseAttestation(QString("direct")) == QString("direct"));
-    QVERIFY(passkeyUtils()->parseAttestation(QString("none")) == QString("none"));
-    QVERIFY(passkeyUtils()->parseAttestation(QString("indirect")) == QString("none"));
-    QVERIFY(passkeyUtils()->parseAttestation(QString("invalidvalue")) == QString("none"));
+    QVERIFY(passkeyUtils()->parseAttestation(QString()) == QStringLiteral("none"));
+    QVERIFY(passkeyUtils()->parseAttestation(QStringLiteral("direct")) == QStringLiteral("direct"));
+    QVERIFY(passkeyUtils()->parseAttestation(QStringLiteral("none")) == QStringLiteral("none"));
+    QVERIFY(passkeyUtils()->parseAttestation(QStringLiteral("indirect")) == QStringLiteral("none"));
+    QVERIFY(passkeyUtils()->parseAttestation(QStringLiteral("invalidvalue")) == QStringLiteral("none"));
 }
 
 void TestPasskeys::testParseCredentialTypes()
@@ -651,7 +651,7 @@ void TestPasskeys::testParseCredentialTypes()
     auto partiallyInvalidResponse = passkeyUtils()->parseCredentialTypes(partiallyInvalidPubKeyCredParams);
     QVERIFY(partiallyInvalidResponse != validPubKeyCredParams);
     QVERIFY(partiallyInvalidResponse.size() == 1);
-    QVERIFY(partiallyInvalidResponse.first()["type"].toString() == QString("public-key"));
+    QVERIFY(partiallyInvalidResponse.first()["type"].toString() == QStringLiteral("public-key"));
     QVERIFY(partiallyInvalidResponse.first()["alg"].toInt() == -257);
 
     auto emptyResponse = passkeyUtils()->parseCredentialTypes({});

--- a/tests/TestPasswordGenerator.cpp
+++ b/tests/TestPasswordGenerator.cpp
@@ -173,17 +173,17 @@ void TestPasswordGenerator::testValidity_data()
                               << PasswordGenerator::GeneratorFlags() << QString() << QString() << 0 << false;
     QTest::addRow("All active classes excluded")
         << to_flags(PasswordGenerator::CharClass::Numbers) << PasswordGenerator::GeneratorFlags() << QString()
-        << QString("0123456789") << PasswordGenerator::DefaultLength << false;
+        << QStringLiteral("0123456789") << PasswordGenerator::DefaultLength << false;
     QTest::addRow("All active classes excluded")
         << to_flags(PasswordGenerator::CharClass::NoClass) << PasswordGenerator::GeneratorFlags() << QString()
-        << QString("0123456789") << PasswordGenerator::DefaultLength << false;
+        << QStringLiteral("0123456789") << PasswordGenerator::DefaultLength << false;
     QTest::addRow("One from every class with too few classes")
         << (PasswordGenerator::CharClass::LowerLetters | PasswordGenerator::CharClass::UpperLetters)
         << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString() << QString() << 1 << false;
     QTest::addRow("One from every class with excluded classes")
         << (PasswordGenerator::CharClass::LowerLetters | PasswordGenerator::CharClass::UpperLetters
             | PasswordGenerator::CharClass::Numbers)
-        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString() << QString("0123456789") << 2
+        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString() << QStringLiteral("0123456789") << 2
         << true;
     QTest::addRow("Defaults valid") << to_flags(PasswordGenerator::CharClass::DefaultCharset)
                                     << to_flags(PasswordGenerator::GeneratorFlag::DefaultFlags)
@@ -192,7 +192,7 @@ void TestPasswordGenerator::testValidity_data()
                                     << true;
     QTest::addRow("No active classes but custom charset")
         << to_flags(PasswordGenerator::CharClass::NoClass) << to_flags(PasswordGenerator::GeneratorFlag::DefaultFlags)
-        << QString("a") << QString() << 1 << true;
+        << QStringLiteral("a") << QString() << 1 << true;
 }
 
 void TestPasswordGenerator::testValidity()
@@ -232,15 +232,15 @@ void TestPasswordGenerator::testMinLength_data()
     QTest::addRow("Classes fully excluded by excluded characters do not count towards min length")
         << (PasswordGenerator::CharClass::Numbers | PasswordGenerator::LowerLetters
             | PasswordGenerator::CharClass::UpperLetters)
-        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString() << QString("0123456789") << 2;
+        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString() << QStringLiteral("0123456789") << 2;
 
     QTest::addRow("Custom charset counts as class")
         << to_flags(PasswordGenerator::CharClass::UpperLetters)
-        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString("a") << QString() << 2;
+        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QStringLiteral("a") << QString() << 2;
     QTest::addRow("Custom characters count even if included by an active class already")
         << (PasswordGenerator::CharClass::LowerLetters | PasswordGenerator::CharClass::UpperLetters
             | PasswordGenerator::CharClass::Numbers)
-        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QString("012345") << QString() << 4;
+        << to_flags(PasswordGenerator::GeneratorFlag::CharFromEveryGroup) << QStringLiteral("012345") << QString() << 4;
 }
 
 void TestPasswordGenerator::testMinLength()

--- a/tests/TestSSHAgent.cpp
+++ b/tests/TestSSHAgent.cpp
@@ -72,7 +72,7 @@ void TestSSHAgent::initTestCase()
     qDebug() << "ssh-agent initialized in" << timer.elapsed() << "ms";
 
     // initialize test key
-    const QString keyString = QString("-----BEGIN OPENSSH PRIVATE KEY-----\n"
+    const QString keyString = QStringLiteral("-----BEGIN OPENSSH PRIVATE KEY-----\n"
                                       "b3BlbnNzaC1rZXktdjEAAAAABG5vbmUAAAAEbm9uZQAAAAAAAAABAAAAMwAAAAtzc2gtZW\n"
                                       "QyNTUxOQAAACDdlO5F2kF2WzedrBAHBi9wBHeISzXZ0IuIqrp0EzeazAAAAKjgCfj94An4\n"
                                       "/QAAAAtzc2gtZWQyNTUxOQAAACDdlO5F2kF2WzedrBAHBi9wBHeISzXZ0IuIqrp0EzeazA\n"
@@ -217,7 +217,7 @@ void TestSSHAgent::testToOpenSSHKey()
 {
     KeeAgentSettings settings;
     settings.setSelectedType("file");
-    settings.setFileName(QString("%1/id_rsa-encrypted-asn1").arg(QString(KEEPASSX_TEST_DATA_DIR)));
+    settings.setFileName(QStringLiteral("%1/id_rsa-encrypted-asn1").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR)));
 
     OpenSSHKey key;
     settings.toOpenSSHKey("username", "correctpassphrase", QString(), nullptr, key, false);

--- a/tests/TestTools.cpp
+++ b/tests/TestTools.cpp
@@ -43,7 +43,7 @@ void TestTools::testHumanReadableFileSize()
     QCOMPARE(createDecimal("1", "00", "MiB"), humanReadableFileSize(kibibyte * kibibyte));
     QCOMPARE(createDecimal("1", "00", "GiB"), humanReadableFileSize(kibibyte * kibibyte * kibibyte));
 
-    QCOMPARE(QString("100 B"), humanReadableFileSize(100, 0));
+    QCOMPARE(QStringLiteral("100 B"), humanReadableFileSize(100, 0));
     QCOMPARE(createDecimal("1", "10", "KiB"), humanReadableFileSize(kibibyte + 100));
     QCOMPARE(createDecimal("1", "001", "KiB"), humanReadableFileSize(kibibyte + 1, 3));
     QCOMPARE(createDecimal("15", "00", "KiB"), humanReadableFileSize(kibibyte * 15));
@@ -86,18 +86,18 @@ void TestTools::testEnvSubstitute()
     environment.insert("USERPROFILE", "C:\\Users\\User");
 
     QCOMPARE(Tools::envSubstitute("%HOMEDRIVE%%HOMEPATH%\\.ssh\\id_rsa", environment),
-             QString("C:\\Users\\User\\.ssh\\id_rsa"));
-    QCOMPARE(Tools::envSubstitute("start%EMPTY%%EMPTY%%%HOMEDRIVE%%end", environment), QString("start%C:%end"));
+             QStringLiteral("C:\\Users\\User\\.ssh\\id_rsa"));
+    QCOMPARE(Tools::envSubstitute("start%EMPTY%%EMPTY%%%HOMEDRIVE%%end", environment), QStringLiteral("start%C:%end"));
     QCOMPARE(Tools::envSubstitute("%USERPROFILE%\\.ssh\\id_rsa", environment),
-             QString("C:\\Users\\User\\.ssh\\id_rsa"));
-    QCOMPARE(Tools::envSubstitute("~\\.ssh\\id_rsa", environment), QString("C:\\Users\\User\\.ssh\\id_rsa"));
+             QStringLiteral("C:\\Users\\User\\.ssh\\id_rsa"));
+    QCOMPARE(Tools::envSubstitute("~\\.ssh\\id_rsa", environment), QStringLiteral("C:\\Users\\User\\.ssh\\id_rsa"));
 #else
-    environment.insert("HOME", QString("/home/user"));
-    environment.insert("USER", QString("user"));
+    environment.insert("HOME", QStringLiteral("/home/user"));
+    environment.insert("USER", QStringLiteral("user"));
 
-    QCOMPARE(Tools::envSubstitute("~/.ssh/id_rsa", environment), QString("/home/user/.ssh/id_rsa"));
-    QCOMPARE(Tools::envSubstitute("$HOME/.ssh/id_rsa", environment), QString("/home/user/.ssh/id_rsa"));
-    QCOMPARE(Tools::envSubstitute("start/$EMPTY$$EMPTY$HOME/end", environment), QString("start/$/home/user/end"));
+    QCOMPARE(Tools::envSubstitute("~/.ssh/id_rsa", environment), QStringLiteral("/home/user/.ssh/id_rsa"));
+    QCOMPARE(Tools::envSubstitute("$HOME/.ssh/id_rsa", environment), QStringLiteral("/home/user/.ssh/id_rsa"));
+    QCOMPARE(Tools::envSubstitute("start/$EMPTY$$EMPTY$HOME/end", environment), QStringLiteral("start/$/home/user/end"));
 #endif
 }
 
@@ -133,9 +133,9 @@ void TestTools::testBackupFilePatternSubstitution_data()
     auto DEFAULT_FORMATTED_TIME = NOW.toString("dd_MM_yyyy_hh-mm-ss");
 
     QTest::newRow("Null pattern") << QString() << DEFAULT_DB_FILE_PATH << QString();
-    QTest::newRow("Empty pattern") << QString("") << DEFAULT_DB_FILE_PATH << QString("");
+    QTest::newRow("Empty pattern") << QString() << DEFAULT_DB_FILE_PATH << QString();
     QTest::newRow("Null database path") << "valid_pattern" << QString() << QString();
-    QTest::newRow("Empty database path") << "valid_pattern" << QString("") << QString();
+    QTest::newRow("Empty database path") << "valid_pattern" << QString() << QString();
     QTest::newRow("Unclosed/invalid pattern") << "{DB_FILENAME" << DEFAULT_DB_FILE_PATH << "{DB_FILENAME";
     QTest::newRow("Unknown pattern") << "{NO_MATCH}" << DEFAULT_DB_FILE_PATH << "{NO_MATCH}";
     QTest::newRow("Do not replace escaped patterns (filename)")
@@ -220,7 +220,7 @@ void TestTools::testConvertToRegex_data()
     QTest::addColumn<QString>("expected");
 
     QTest::newRow("No Options") << input << static_cast<int>(Tools::RegexConvertOpts::DEFAULT)
-                                << QString(R"(te|st*t?[5]^(test);',.)");
+                                << QStringLiteral(R"(te|st*t?[5]^(test);',.)");
     // Escape regex
     QTest::newRow("Escape Regex") << input << static_cast<int>(Tools::RegexConvertOpts::ESCAPE_REGEX)
                                   << Tools::escapeRegex(input);
@@ -230,22 +230,22 @@ void TestTools::testConvertToRegex_data()
 
     // Exact match does not escape the pattern
     QTest::newRow("Exact Match 1") << input << static_cast<int>(Tools::RegexConvertOpts::EXACT_MATCH)
-                                 << QString(R"(^(?:te|st*t?[5]^(test);',.)$)");
+                                 << QStringLiteral(R"(^(?:te|st*t?[5]^(test);',.)$)");
 
     // Exact match with improper regex
     QTest::newRow("Exact Match 2") << ")av(" << static_cast<int>(Tools::RegexConvertOpts::EXACT_MATCH)
-                                 << QString(R"(^(?:)av()$)");
+                                 << QStringLiteral(R"(^(?:)av()$)");
 
     QTest::newRow("Exact Match & Wildcard")
         << input << static_cast<int>(Tools::RegexConvertOpts::EXACT_MATCH | Tools::RegexConvertOpts::WILDCARD_ALL)
-        << QString(R"(^(?:te|st.*t.\[5\]\^\(test\)\;\'\,\.)$)");
+        << QStringLiteral(R"(^(?:te|st.*t.\[5\]\^\(test\)\;\'\,\.)$)");
     QTest::newRow("Wildcard Single Match") << input << static_cast<int>(Tools::RegexConvertOpts::WILDCARD_SINGLE_MATCH)
-                                           << QString(R"(te\|st\*t.\[5\]\^\(test\)\;\'\,\.)");
+                                           << QStringLiteral(R"(te\|st\*t.\[5\]\^\(test\)\;\'\,\.)");
     QTest::newRow("Wildcard OR") << input << static_cast<int>(Tools::RegexConvertOpts::WILDCARD_LOGICAL_OR)
-                                 << QString(R"(te|st\*t\?\[5\]\^\(test\)\;\'\,\.)");
+                                 << QStringLiteral(R"(te|st\*t\?\[5\]\^\(test\)\;\'\,\.)");
     QTest::newRow("Wildcard Unlimited Match")
         << input << static_cast<int>(Tools::RegexConvertOpts::WILDCARD_UNLIMITED_MATCH)
-        << QString(R"(te\|st.*t\?\[5\]\^\(test\)\;\'\,\.)");
+        << QStringLiteral(R"(te\|st.*t\?\[5\]\^\(test\)\;\'\,\.)");
 }
 
 void TestTools::testArrayContainsValues()
@@ -260,7 +260,7 @@ void TestTools::testArrayContainsValues()
                                                                                 << "second"
                                                                                 << "none");
     QCOMPARE(result1.length(), 1);
-    QCOMPARE(result1.first(), QString("none"));
+    QCOMPARE(result1.first(), QStringLiteral("none"));
 
     // All found
     const auto result2 = Tools::getMissingValuesFromList<QString>(values,

--- a/tests/TestTotp.cpp
+++ b/tests/TestTotp.cpp
@@ -39,7 +39,7 @@ void TestTotp::testParseSecret()
                      "SHA1&digits=6&period=30";
     auto settings = Totp::parseSettings(secret);
     QVERIFY(!settings.isNull());
-    QCOMPARE(settings->key, QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
     QCOMPARE(settings->custom, false);
     QCOMPARE(settings->format, Totp::StorageFormat::OTPURL);
     QCOMPARE(settings->digits, 6u);
@@ -52,7 +52,7 @@ void TestTotp::testParseSecret()
              "SHA512&digits=6&period=30";
     settings = Totp::parseSettings(secret);
     QVERIFY(!settings.isNull());
-    QCOMPARE(settings->key, QString("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRB3HWIZR4IFUGFTMXBOZ"));
     QCOMPARE(settings->custom, true);
     QCOMPARE(settings->format, Totp::StorageFormat::OTPURL);
     QCOMPARE(settings->digits, 6u);
@@ -69,7 +69,7 @@ void TestTotp::testParseSecret()
     secret = "key=HXDMVJECJJWSRBY%3d&step=25&size=8&otpHashMode=Sha256";
     settings = Totp::parseSettings(secret);
     QVERIFY(!settings.isNull());
-    QCOMPARE(settings->key, QString("HXDMVJECJJWSRBY="));
+    QCOMPARE(settings->key, QStringLiteral("HXDMVJECJJWSRBY="));
     QCOMPARE(settings->custom, true);
     QCOMPARE(settings->format, Totp::StorageFormat::KEEOTP);
     QCOMPARE(settings->digits, 8u);
@@ -80,7 +80,7 @@ void TestTotp::testParseSecret()
     secret = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
     settings = Totp::parseSettings("30;8", secret);
     QVERIFY(!settings.isNull());
-    QCOMPARE(settings->key, QString("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
+    QCOMPARE(settings->key, QStringLiteral("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
     QCOMPARE(settings->custom, true);
     QCOMPARE(settings->format, Totp::StorageFormat::LEGACY);
     QCOMPARE(settings->digits, 8u);
@@ -91,7 +91,7 @@ void TestTotp::testParseSecret()
     secret = "gezdgnbvgy3tqojqgezdgnbvgy3tqojq";
     settings = Totp::parseSettings("", secret);
     QVERIFY(!settings.isNull());
-    QCOMPARE(settings->key, QString("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
+    QCOMPARE(settings->key, QStringLiteral("gezdgnbvgy3tqojqgezdgnbvgy3tqojq"));
     QCOMPARE(settings->custom, false);
     QCOMPARE(settings->format, Totp::StorageFormat::LEGACY);
     QCOMPARE(settings->digits, 6u);
@@ -115,19 +115,19 @@ void TestTotp::testTotpCode()
 
     // Test 6 digit TOTP (default)
     quint64 time = 1234567890;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("005924"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("005924"));
 
     time = 1111111109;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("081804"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("081804"));
 
     // Test 8 digit TOTP (custom)
     settings->digits = 8;
     settings->custom = true;
     time = 1111111111;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("14050471"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("14050471"));
 
     time = 2000000000;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("69279037"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("69279037"));
 }
 
 void TestTotp::testSteamTotp()
@@ -138,7 +138,7 @@ void TestTotp::testSteamTotp()
                      "SHA1&digits=5&period=30&encoder=steam";
     auto settings = Totp::parseSettings(secret);
 
-    QCOMPARE(settings->key, QString("63BEDWCQZKTQWPESARIERL5DTTQFCJTK"));
+    QCOMPARE(settings->key, QStringLiteral("63BEDWCQZKTQWPESARIERL5DTTQFCJTK"));
     QCOMPARE(settings->encoder.shortName, Totp::STEAM_SHORTNAME);
     QCOMPARE(settings->format, Totp::StorageFormat::OTPURL);
     QCOMPARE(settings->digits, Totp::STEAM_DIGITS);
@@ -148,9 +148,9 @@ void TestTotp::testSteamTotp()
     // Steam mobile app with a throw-away steam account. The above secret was extracted
     // from the Steam app's data for use in testing here.
     quint64 time = 1511200518;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("FR8RV"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("FR8RV"));
     time = 1511200714;
-    QCOMPARE(Totp::generateTotp(settings, time), QString("9P3VP"));
+    QCOMPARE(Totp::generateTotp(settings, time), QStringLiteral("9P3VP"));
 }
 
 void TestTotp::testEntryHistory()
@@ -166,12 +166,12 @@ void TestTotp::testEntryHistory()
     entry.setTotp(settings);
     QCOMPARE(entry.historyItems().size(), 1);
     QVERIFY(entry.hasTotp());
-    QCOMPARE(entry.totpSettings()->key, QString("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"));
+    QCOMPARE(entry.totpSettings()->key, QStringLiteral("GEZDGNBVGY3TQOJQGEZDGNBVGY3TQOJQ"));
     // Change key and verify settings changed
     settings->key = "foo";
     entry.setTotp(settings);
     QCOMPARE(entry.historyItems().size(), 2);
-    QCOMPARE(entry.totpSettings()->key, QString("foo"));
+    QCOMPARE(entry.totpSettings()->key, QStringLiteral("foo"));
     // Nullptr Settings (expected reset of TOTP)
     entry.setTotp(nullptr);
     QVERIFY(!entry.hasTotp());

--- a/tests/TestUpdateCheck.cpp
+++ b/tests/TestUpdateCheck.cpp
@@ -31,31 +31,31 @@ void TestUpdateCheck::initTestCase()
 void TestUpdateCheck::testCompareVersion()
 {
     // No upgrade
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0"), QString("2.3.0")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0"), QStringLiteral("2.3.0")), false);
 
     // First digit upgrade
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.4.0"), QString("3.0.0")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("3.0.0"), QString("2.4.0")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.4.0"), QStringLiteral("3.0.0")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("3.0.0"), QStringLiteral("2.4.0")), false);
 
     // Second digit upgrade
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.4"), QString("2.4.0")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.4.0"), QString("2.3.4")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.4"), QStringLiteral("2.4.0")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.4.0"), QStringLiteral("2.3.4")), false);
 
     // Third digit upgrade
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0"), QString("2.3.1")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.1"), QString("2.3.0")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0"), QStringLiteral("2.3.1")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.1"), QStringLiteral("2.3.0")), false);
 
     // Beta builds
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0"), QString("2.3.0-beta1")), false);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0"), QString("2.3.1-beta1")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0-beta1"), QString("2.3.0")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0-beta"), QString("2.3.0-beta1")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0-beta1"), QString("2.3.0-beta")), false);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0-beta1"), QString("2.3.0-beta2")), true);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.0-beta2"), QString("2.3.0-beta1")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0"), QStringLiteral("2.3.0-beta1")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0"), QStringLiteral("2.3.1-beta1")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0-beta1"), QStringLiteral("2.3.0")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0-beta"), QStringLiteral("2.3.0-beta1")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0-beta1"), QStringLiteral("2.3.0-beta")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0-beta1"), QStringLiteral("2.3.0-beta2")), true);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.0-beta2"), QStringLiteral("2.3.0-beta1")), false);
 
     // Snapshot and invalid data
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.3.4-snapshot"), QString("2.4.0")), false);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.4.0"), QString("invalid")), false);
-    QCOMPARE(UpdateChecker::compareVersions(QString("2.4.0"), QString("")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.3.4-snapshot"), QStringLiteral("2.4.0")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.4.0"), QStringLiteral("invalid")), false);
+    QCOMPARE(UpdateChecker::compareVersions(QStringLiteral("2.4.0"), QString()), false);
 }

--- a/tests/TestUrlTools.cpp
+++ b/tests/TestUrlTools.cpp
@@ -33,19 +33,19 @@ void TestUrlTools::testTopLevelDomain()
 {
     // Create list of URLs and expected TLD responses
     QList<QPair<QString, QString>> tldUrls{
-        {QString("https://another.example.co.uk"), QString("co.uk")},
-        {QString("https://www.example.com"), QString("com")},
-        {QString("https://example.com"), QString("com")},
-        {QString("https://github.com"), QString("com")},
-        {QString("http://test.net"), QString("net")},
-        {QString("http://so.many.subdomains.co.jp"), QString("co.jp")},
-        {QString("https://192.168.0.1"), QString("192.168.0.1")},
-        {QString("https://192.168.0.1:8000"), QString("192.168.0.1")},
-        {QString("https://www.nic.ar"), QString("ar")},
-        {QString("https://no.no.no"), QString("no")},
-        {QString("https://www.blogspot.com.ar"), QString("blogspot.com.ar")}, // blogspot.com.ar is a TLD
-        {QString("https://jap.an.ide.kyoto.jp"), QString("ide.kyoto.jp")}, // ide.kyoto.jp is a TLD
-        {QString("ar"), QString("ar")},
+        {QStringLiteral("https://another.example.co.uk"), QStringLiteral("co.uk")},
+        {QStringLiteral("https://www.example.com"), QStringLiteral("com")},
+        {QStringLiteral("https://example.com"), QStringLiteral("com")},
+        {QStringLiteral("https://github.com"), QStringLiteral("com")},
+        {QStringLiteral("http://test.net"), QStringLiteral("net")},
+        {QStringLiteral("http://so.many.subdomains.co.jp"), QStringLiteral("co.jp")},
+        {QStringLiteral("https://192.168.0.1"), QStringLiteral("192.168.0.1")},
+        {QStringLiteral("https://192.168.0.1:8000"), QStringLiteral("192.168.0.1")},
+        {QStringLiteral("https://www.nic.ar"), QStringLiteral("ar")},
+        {QStringLiteral("https://no.no.no"), QStringLiteral("no")},
+        {QStringLiteral("https://www.blogspot.com.ar"), QStringLiteral("blogspot.com.ar")}, // blogspot.com.ar is a TLD
+        {QStringLiteral("https://jap.an.ide.kyoto.jp"), QStringLiteral("ide.kyoto.jp")}, // ide.kyoto.jp is a TLD
+        {QStringLiteral("ar"), QStringLiteral("ar")},
     };
 
     for (const auto& u : tldUrls) {
@@ -54,17 +54,17 @@ void TestUrlTools::testTopLevelDomain()
 
     // Create list of URLs and expected base URL responses
     QList<QPair<QString, QString>> baseUrls{
-        {QString("https://another.example.co.uk"), QString("example.co.uk")},
-        {QString("https://www.example.com"), QString("example.com")},
-        {QString("http://test.net"), QString("test.net")},
-        {QString("http://so.many.subdomains.co.jp"), QString("subdomains.co.jp")},
-        {QString("https://192.168.0.1"), QString("192.168.0.1")},
-        {QString("https://192.168.0.1:8000"), QString("192.168.0.1")},
-        {QString("https://www.nic.ar"), QString("nic.ar")},
-        {QString("https://www.blogspot.com.ar"), QString("www.blogspot.com.ar")}, // blogspot.com.ar is a TLD
-        {QString("https://www.arpa"), QString("www.arpa")},
-        {QString("https://jap.an.ide.kyoto.jp"), QString("an.ide.kyoto.jp")}, // ide.kyoto.jp is a TLD
-        {QString("https://kobe.jp"), QString("kobe.jp")},
+        {QStringLiteral("https://another.example.co.uk"), QStringLiteral("example.co.uk")},
+        {QStringLiteral("https://www.example.com"), QStringLiteral("example.com")},
+        {QStringLiteral("http://test.net"), QStringLiteral("test.net")},
+        {QStringLiteral("http://so.many.subdomains.co.jp"), QStringLiteral("subdomains.co.jp")},
+        {QStringLiteral("https://192.168.0.1"), QStringLiteral("192.168.0.1")},
+        {QStringLiteral("https://192.168.0.1:8000"), QStringLiteral("192.168.0.1")},
+        {QStringLiteral("https://www.nic.ar"), QStringLiteral("nic.ar")},
+        {QStringLiteral("https://www.blogspot.com.ar"), QStringLiteral("www.blogspot.com.ar")}, // blogspot.com.ar is a TLD
+        {QStringLiteral("https://www.arpa"), QStringLiteral("www.arpa")},
+        {QStringLiteral("https://jap.an.ide.kyoto.jp"), QStringLiteral("an.ide.kyoto.jp")}, // ide.kyoto.jp is a TLD
+        {QStringLiteral("https://kobe.jp"), QStringLiteral("kobe.jp")},
     };
 
     for (const auto& u : baseUrls) {

--- a/tests/TestYkChallengeResponseKey.cpp
+++ b/tests/TestYkChallengeResponseKey.cpp
@@ -87,5 +87,5 @@ void TestYubiKeyChallengeResponse::testKeyChallenge()
     QVERIFY(key->challenge(ba));
     QCOMPARE(key->rawKey().size(), 20);
     auto hash = QString(QCryptographicHash::hash(key->rawKey(), QCryptographicHash::Sha256).toHex());
-    QCOMPARE(hash, QString("2f7802c7112c301303526e7737b54d546c905076dca6e9538edf761a2264cd70"));
+    QCOMPARE(hash, QStringLiteral("2f7802c7112c301303526e7737b54d546c905076dca6e9538edf761a2264cd70"));
 }

--- a/tests/gui/TestGui.cpp
+++ b/tests/gui/TestGui.cpp
@@ -277,12 +277,12 @@ void TestGui::testCreateDatabase()
         auto* fileEdit = keyFileWidget->findChild<QLineEdit*>("keyFileLineEdit");
         QTRY_VERIFY(fileEdit);
         QTRY_VERIFY(fileEdit->isVisible());
-        fileDialog()->setNextFileName(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
+        fileDialog()->setNextFileName(QStringLiteral("%1/%2").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
         QTest::keyClick(keyFileWidget->findChild<QPushButton*>("addButton"), Qt::Key::Key_Enter);
         QVERIFY(fileEdit->hasFocus());
         auto* browseButton = keyFileWidget->findChild<QPushButton*>("browseKeyFileButton");
         QTest::keyClick(browseButton, Qt::Key::Key_Enter);
-        QCOMPARE(fileEdit->text(), QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
+        QCOMPARE(fileEdit->text(), QStringLiteral("%1/%2").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
 
         // save database to temporary file
         TemporaryFile tmpFile;
@@ -307,8 +307,8 @@ void TestGui::testCreateDatabase()
     QCOMPARE(m_db->rootGroup()->children().size(), 0);
 
     // check meta data
-    QCOMPARE(m_db->metadata()->name(), QString("Test Name"));
-    QCOMPARE(m_db->metadata()->description(), QString("Test Description"));
+    QCOMPARE(m_db->metadata()->name(), QStringLiteral("Test Name"));
+    QCOMPARE(m_db->metadata()->description(), QStringLiteral("Test Description"));
 
     // check key and encryption
     QCOMPARE(m_db->key()->keys().size(), 2);
@@ -318,7 +318,7 @@ void TestGui::testCreateDatabase()
     auto compositeKey = QSharedPointer<CompositeKey>::create();
     compositeKey->addKey(QSharedPointer<PasswordKey>::create("test"));
     auto fileKey = QSharedPointer<FileKey>::create();
-    fileKey->load(QString("%1/%2").arg(QString(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
+    fileKey->load(QStringLiteral("%1/%2").arg(QStringLiteral(KEEPASSX_TEST_DATA_DIR), "FileKeyHashed.key"));
     compositeKey->addKey(fileKey);
     QCOMPARE(m_db->key()->rawKey(), compositeKey->rawKey());
 
@@ -346,10 +346,10 @@ void TestGui::testMergeDatabase()
     QApplication::processEvents();
 
     // set file to merge from
-    fileDialog()->setNextFileName(QString(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx"));
+    fileDialog()->setNextFileName(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx"));
     triggerAction("actionDatabaseMerge");
 
-    QTRY_COMPARE(QApplication::focusWidget()->objectName(), QString("passwordEdit"));
+    QTRY_COMPARE(QApplication::focusWidget()->objectName(), QStringLiteral("passwordEdit"));
     auto* editPasswordMerge = QApplication::focusWidget();
     QVERIFY(editPasswordMerge->isVisible());
 
@@ -376,7 +376,7 @@ void TestGui::testAutoreloadDatabase()
     // Test accepting new file in autoreload
     MessageBox::setNextAnswer(MessageBox::Yes);
     // Overwrite the current database with the temp data
-    QVERIFY(m_dbFile.copyFromFile(QString(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
+    QVERIFY(m_dbFile.copyFromFile(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
 
     QTRY_VERIFY(m_db != m_dbWidget->database());
     m_db = m_dbWidget->database();
@@ -394,7 +394,7 @@ void TestGui::testAutoreloadDatabase()
     // Test rejecting new file in autoreload
     MessageBox::setNextAnswer(MessageBox::No);
     // Overwrite the current database with the temp data
-    QVERIFY(m_dbFile.copyFromFile(QString(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
+    QVERIFY(m_dbFile.copyFromFile(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
 
     // Ensure the merge did not take place
     QCOMPARE(m_db->rootGroup()->findChildByName("General")->entries().size(), 0);
@@ -413,7 +413,7 @@ void TestGui::testAutoreloadDatabase()
     // This is saying yes to merging the entries
     MessageBox::setNextAnswer(MessageBox::Merge);
     // Overwrite the current database with the temp data
-    QVERIFY(m_dbFile.copyFromFile(QString(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
+    QVERIFY(m_dbFile.copyFromFile(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/MergeDatabase.kdbx")));
 
     QTRY_VERIFY(m_db != m_dbWidget->database());
     m_db = m_dbWidget->database();
@@ -469,7 +469,7 @@ void TestGui::testEditEntry()
     QTRY_VERIFY(applyButton->isEnabled());
     QTest::mouseClick(applyButton, Qt::LeftButton);
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::EditMode);
-    QCOMPARE(entry->title(), QString("Sample Entry_test"));
+    QCOMPARE(entry->title(), QStringLiteral("Sample Entry_test"));
     QCOMPARE(entry->historyItems().size(), ++editCount);
     QVERIFY(!applyButton->isEnabled());
 
@@ -487,19 +487,19 @@ void TestGui::testEditEntry()
     auto* tags = editEntryWidget->findChild<TagsEdit*>("tagsList");
     QTest::keyClicks(tags, "_tag1");
     QTest::keyClick(tags, Qt::Key_Return);
-    QCOMPARE(tags->tags().last(), QString("_tag1"));
+    QCOMPARE(tags->tags().last(), QStringLiteral("_tag1"));
     QTest::keyClicks(tags, "tag 2"); // adds another tag
     QTest::keyClick(tags, Qt::Key_Return);
-    QCOMPARE(tags->tags().last(), QString("tag 2"));
+    QCOMPARE(tags->tags().last(), QStringLiteral("tag 2"));
     QTest::keyClick(tags, Qt::Key_Backspace); // Back into editing last tag
     QTest::keyClicks(tags, "_is!awesome");
     QTest::keyClick(tags, Qt::Key_Return);
-    QCOMPARE(tags->tags().last(), QString("tag 2_is!awesome"));
+    QCOMPARE(tags->tags().last(), QStringLiteral("tag 2_is!awesome"));
 
     // Test entry colors (simulate choosing a color)
     editEntryWidget->setCurrentPage(1);
-    auto fgColor = QString("#FF0000");
-    auto bgColor = QString("#0000FF");
+    auto fgColor = QStringLiteral("#FF0000");
+    auto bgColor = QStringLiteral("#0000FF");
     // Set foreground color
     auto colorButton = editEntryWidget->findChild<QPushButton*>("fgColorButton");
     auto colorCheckBox = editEntryWidget->findChild<QCheckBox*>("fgColorCheckBox");
@@ -532,7 +532,7 @@ void TestGui::testEditEntry()
 
     // Confirm edit was made
     QCOMPARE(m_dbWidget->currentMode(), DatabaseWidget::Mode::ViewMode);
-    QCOMPARE(entry->title(), QString("Sample Entry_test"));
+    QCOMPARE(entry->title(), QStringLiteral("Sample Entry_test"));
     QCOMPARE(entry->foregroundColor().toUpper(), fgColor.toUpper());
     QCOMPARE(entryItem.data(Qt::ForegroundRole), QVariant(fgColor));
     QCOMPARE(entry->backgroundColor().toUpper(), bgColor.toUpper());
@@ -540,7 +540,7 @@ void TestGui::testEditEntry()
     QCOMPARE(entry->historyItems().size(), ++editCount);
 
     // Confirm modified indicator is showing
-    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("%1*").arg(m_dbFileName));
+    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QStringLiteral("%1*").arg(m_dbFileName));
 
     // Test copy & paste newline sanitization
     QTest::mouseClick(entryEditWidget, Qt::LeftButton);
@@ -553,11 +553,11 @@ void TestGui::testEditEntry()
     editEntryWidget->findChild<QLineEdit*>("urlEdit")->setText("multiline\nurl");
     QTest::mouseClick(okButton, Qt::LeftButton);
 
-    QCOMPARE(entry->title(), QString("multiline title"));
-    QCOMPARE(entry->username(), QString("multiline username"));
+    QCOMPARE(entry->title(), QStringLiteral("multiline title"));
+    QCOMPARE(entry->username(), QStringLiteral("multiline username"));
     // here we keep newlines, so users can't lock themselves out accidentally
-    QCOMPARE(entry->password(), QString("multiline\npassword"));
-    QCOMPARE(entry->url(), QString("multiline url"));
+    QCOMPARE(entry->password(), QStringLiteral("multiline\npassword"));
+    QCOMPARE(entry->url(), QStringLiteral("multiline url"));
 }
 
 void TestGui::testSearchEditEntry()
@@ -587,13 +587,13 @@ void TestGui::testSearchEditEntry()
     auto* editEntryWidgetButtonBox = editEntryWidget->findChild<QDialogButtonBox*>("buttonBox");
 
     // Create "Doggy" in "Good"
-    Group* goodGroup = m_dbWidget->currentGroup()->findChildByName(QString("Good"));
+    Group* goodGroup = m_dbWidget->currentGroup()->findChildByName(QStringLiteral("Good"));
     m_dbWidget->groupView()->setCurrentGroup(goodGroup);
     QTest::mouseClick(entryNewWidget, Qt::LeftButton);
     QTest::keyClicks(titleEdit, "Doggy");
     QTest::mouseClick(editEntryWidgetButtonBox->button(QDialogButtonBox::Ok), Qt::LeftButton);
     // Select "Bad" group in groupView
-    Group* badGroup = m_db->rootGroup()->findChildByName(QString("Bad"));
+    Group* badGroup = m_db->rootGroup()->findChildByName(QStringLiteral("Bad"));
     m_dbWidget->groupView()->setCurrentGroup(badGroup);
 
     // Search for "Doggy" entry
@@ -648,8 +648,8 @@ void TestGui::testAddEntry()
     QModelIndex item = entryView->model()->index(1, 1);
     Entry* entry = entryView->entryFromIndex(item);
 
-    QCOMPARE(entry->title(), QString("test"));
-    QCOMPARE(entry->username(), QString("AutocompletionUsername"));
+    QCOMPARE(entry->title(), QStringLiteral("test"));
+    QCOMPARE(entry->username(), QStringLiteral("AutocompletionUsername"));
     QCOMPARE(entry->historyItems().size(), 0);
 
     m_db->updateCommonUsernames();
@@ -672,8 +672,8 @@ void TestGui::testAddEntry()
     item = entryView->model()->index(1, 1);
     entry = entryView->entryFromIndex(item);
 
-    QCOMPARE(entry->title(), QString("something 2"));
-    QCOMPARE(entry->username(), QString("AutocompletionUsername"));
+    QCOMPARE(entry->title(), QStringLiteral("something 2"));
+    QCOMPARE(entry->username(), QStringLiteral("AutocompletionUsername"));
     QCOMPARE(entry->historyItems().size(), 0);
 
     // Add entry "something 5" but click cancel button (does NOT add entry)
@@ -870,8 +870,8 @@ void TestGui::testDicewareEntryEntropy()
         auto* strengthLabel = pwGeneratorWidget->findChild<QLabel*>("strengthLabel");
         auto* wordLengthLabel = pwGeneratorWidget->findChild<QLabel*>("charactersInPassphraseLabel");
 
-        QTRY_COMPARE_WITH_TIMEOUT(entropyLabel->text(), QString("Entropy: 77.55 bit"), 200);
-        QCOMPARE(strengthLabel->text(), QString("Password Quality: Good"));
+        QTRY_COMPARE_WITH_TIMEOUT(entropyLabel->text(), QStringLiteral("Entropy: 77.55 bit"), 200);
+        QCOMPARE(strengthLabel->text(), QStringLiteral("Password Quality: Good"));
         QCOMPARE(wordLengthLabel->text().toInt(), pwGeneratorWidget->getGeneratedPassword().size());
 
         QTest::mouseClick(generatedPassword, Qt::LeftButton);
@@ -987,7 +987,7 @@ void TestGui::testSearch()
 
     // Search for "ZZZ"
     QTest::keyClicks(searchTextEdit, "ZZZ");
-    QTRY_COMPARE(searchTextEdit->text(), QString("ZZZ"));
+    QTRY_COMPARE(searchTextEdit->text(), QStringLiteral("ZZZ"));
     QTRY_VERIFY(m_dbWidget->isSearchActive());
     QTRY_COMPARE(entryView->model()->rowCount(), 0);
     // Press the search clear button
@@ -1026,7 +1026,7 @@ void TestGui::testSearch()
     // Restore focus using F3 key and search text selection
     QTest::keyClick(m_mainWindow.data(), Qt::Key_F3);
     QTRY_VERIFY(searchTextEdit->hasFocus());
-    QTRY_COMPARE(searchTextEdit->selectedText(), QString("someTHING"));
+    QTRY_COMPARE(searchTextEdit->selectedText(), QStringLiteral("someTHING"));
 
     searchedEntry->setPassword("password");
     QClipboard* clipboard = QApplication::clipboard();
@@ -1054,7 +1054,7 @@ void TestGui::testSearch()
     // Test that password does not copy
     searchTextEdit->selectAll();
     QTest::keyClick(searchTextEdit, Qt::Key_C, Qt::ControlModifier);
-    QTRY_COMPARE(clipboard->text(), QString("someTHING"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("someTHING"));
 
     // Test case sensitive search
     searchWidget->setCaseSensitive(true);
@@ -1068,7 +1068,7 @@ void TestGui::testSearch()
     QCOMPARE(groupView->currentGroup(), m_db->rootGroup());
     QModelIndex rootGroupIndex = groupView->model()->index(0, 0);
     clickIndex(groupView->model()->index(0, 0, rootGroupIndex), groupView, Qt::LeftButton);
-    QCOMPARE(groupView->currentGroup()->name(), QString("General"));
+    QCOMPARE(groupView->currentGroup()->name(), QStringLiteral("General"));
     // Selecting a group should cancel search
     QTRY_COMPARE(entryView->model()->rowCount(), 0);
     // Restore search
@@ -1244,7 +1244,7 @@ void TestGui::testCloneEntry()
     QCOMPARE(entryView->model()->rowCount(), 2);
     Entry* entryClone = entryView->entryFromIndex(entryView->model()->index(1, 1));
     QVERIFY(entryOrg->uuid() != entryClone->uuid());
-    QCOMPARE(entryClone->title(), entryOrg->title() + QString(" - Clone"));
+    QCOMPARE(entryClone->title(), entryOrg->title() + QStringLiteral(" - Clone"));
     QVERIFY(m_dbWidget->currentSelectedEntry()->uuid() == entryClone->uuid());
 }
 
@@ -1283,13 +1283,13 @@ void TestGui::testEntryPlaceholders()
     QModelIndex item = entryView->model()->index(1, 1);
     Entry* entry = entryView->entryFromIndex(item);
 
-    QCOMPARE(entry->title(), QString("test"));
-    QCOMPARE(entry->url(), QString("{TITLE}.{USERNAME}"));
+    QCOMPARE(entry->title(), QStringLiteral("test"));
+    QCOMPARE(entry->url(), QStringLiteral("{TITLE}.{USERNAME}"));
 
     // Test password copy
     QClipboard* clipboard = QApplication::clipboard();
     m_dbWidget->copyURL();
-    QTRY_COMPARE(clipboard->text(), QString("test.john"));
+    QTRY_COMPARE(clipboard->text(), QStringLiteral("test.john"));
 }
 
 void TestGui::testDragAndDropEntry()
@@ -1328,9 +1328,9 @@ void TestGui::testDragAndDropEntry()
     mimeData.setData("application/x-keepassx-entry", encoded);
 
     // Test Move, entry pointer should remain the same
-    QCOMPARE(entry->group()->name(), QString("NewDatabase"));
+    QCOMPARE(entry->group()->name(), QStringLiteral("NewDatabase"));
     QVERIFY(groupModel->dropMimeData(&mimeData, Qt::MoveAction, -1, 0, targetIndex));
-    QCOMPARE(entry->group()->name(), QString("General"));
+    QCOMPARE(entry->group()->name(), QStringLiteral("General"));
     QCOMPARE(entry->uuid(), uuid);
     QCOMPARE(entry->historyItems().count(), history);
 }
@@ -1372,7 +1372,7 @@ void TestGui::testSaveAs()
 
     triggerAction("actionDatabaseSaveAs");
 
-    QCOMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("testSaveAs"));
+    QCOMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QStringLiteral("testSaveAs"));
 
     checkDatabase(tmpFileName);
 
@@ -1395,13 +1395,13 @@ void TestGui::testSaveBackup()
     tmpFile.remove();
 
     // wait for modified timer
-    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("testSaveBackup*"));
+    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QStringLiteral("testSaveBackup*"));
 
     fileDialog()->setNextFileName(tmpFileName);
 
     triggerAction("actionDatabaseSaveBackup");
 
-    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QString("testSaveBackup*"));
+    QTRY_COMPARE(m_tabWidget->tabText(m_tabWidget->currentIndex()), QStringLiteral("testSaveBackup*"));
 
     checkDatabase(tmpFileName);
 
@@ -1437,7 +1437,7 @@ void TestGui::testSaveBackupPath_data()
     QTest::newRow("Path with placeholders") << "{DB_FILENAME}.old.kdbx"
                                             << "KeePassXC.old.kdbx";
     // empty path should be replaced with default pattern
-    QTest::newRow("Empty path") << QString("") << config()->getDefault(Config::BackupFilePathPattern).toString();
+    QTest::newRow("Empty path") << QString() << config()->getDefault(Config::BackupFilePathPattern).toString();
     // {DB_FILENAME} should be replaced with database filename
     QTest::newRow("") << "{DB_FILENAME}_.old.kdbx"
                       << "{DB_FILENAME}_.old.kdbx";
@@ -1675,8 +1675,8 @@ void TestGui::testDragAndDropKdbxFiles()
 {
     const int openedDatabasesCount = m_tabWidget->count();
 
-    const QString badDatabaseFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/NotDatabase.notkdbx"));
-    const QString goodDatabaseFilePath(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.kdbx"));
+    const QString badDatabaseFilePath(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NotDatabase.notkdbx"));
+    const QString goodDatabaseFilePath(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewDatabase.kdbx"));
 
     QMimeData badMimeData;
     badMimeData.setUrls({QUrl::fromLocalFile(badDatabaseFilePath)});
@@ -1737,63 +1737,63 @@ void TestGui::testSortGroups()
 
     triggerAction("actionGroupSortAsc");
     QList<Group*> children = rootGroup->children();
-    QCOMPARE(children[0]->name(), QString("eMail"));
-    QCOMPARE(children[1]->name(), QString("General"));
-    QCOMPARE(children[2]->name(), QString("Homebanking"));
-    QCOMPARE(children[3]->name(), QString("Internet"));
-    QCOMPARE(children[4]->name(), QString("Network"));
-    QCOMPARE(children[5]->name(), QString("Windows"));
+    QCOMPARE(children[0]->name(), QStringLiteral("eMail"));
+    QCOMPARE(children[1]->name(), QStringLiteral("General"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Homebanking"));
+    QCOMPARE(children[3]->name(), QStringLiteral("Internet"));
+    QCOMPARE(children[4]->name(), QStringLiteral("Network"));
+    QCOMPARE(children[5]->name(), QStringLiteral("Windows"));
     QList<Group*> subChildren = internetGroup->children();
-    QCOMPARE(subChildren[0]->name(), QString("Amazon"));
-    QCOMPARE(subChildren[1]->name(), QString("eBay"));
-    QCOMPARE(subChildren[2]->name(), QString("Facebook"));
-    QCOMPARE(subChildren[3]->name(), QString("Google"));
+    QCOMPARE(subChildren[0]->name(), QStringLiteral("Amazon"));
+    QCOMPARE(subChildren[1]->name(), QStringLiteral("eBay"));
+    QCOMPARE(subChildren[2]->name(), QStringLiteral("Facebook"));
+    QCOMPARE(subChildren[3]->name(), QStringLiteral("Google"));
 
     triggerAction("actionGroupSortDesc");
     children = rootGroup->children();
-    QCOMPARE(children[0]->name(), QString("Windows"));
-    QCOMPARE(children[1]->name(), QString("Network"));
-    QCOMPARE(children[2]->name(), QString("Internet"));
-    QCOMPARE(children[3]->name(), QString("Homebanking"));
-    QCOMPARE(children[4]->name(), QString("General"));
-    QCOMPARE(children[5]->name(), QString("eMail"));
+    QCOMPARE(children[0]->name(), QStringLiteral("Windows"));
+    QCOMPARE(children[1]->name(), QStringLiteral("Network"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Internet"));
+    QCOMPARE(children[3]->name(), QStringLiteral("Homebanking"));
+    QCOMPARE(children[4]->name(), QStringLiteral("General"));
+    QCOMPARE(children[5]->name(), QStringLiteral("eMail"));
     subChildren = internetGroup->children();
-    QCOMPARE(subChildren[0]->name(), QString("Google"));
-    QCOMPARE(subChildren[1]->name(), QString("Facebook"));
-    QCOMPARE(subChildren[2]->name(), QString("eBay"));
-    QCOMPARE(subChildren[3]->name(), QString("Amazon"));
+    QCOMPARE(subChildren[0]->name(), QStringLiteral("Google"));
+    QCOMPARE(subChildren[1]->name(), QStringLiteral("Facebook"));
+    QCOMPARE(subChildren[2]->name(), QStringLiteral("eBay"));
+    QCOMPARE(subChildren[3]->name(), QStringLiteral("Amazon"));
 
     m_dbWidget->groupView()->setCurrentGroup(internetGroup);
     triggerAction("actionGroupSortAsc");
     children = rootGroup->children();
-    QCOMPARE(children[0]->name(), QString("Windows"));
-    QCOMPARE(children[1]->name(), QString("Network"));
-    QCOMPARE(children[2]->name(), QString("Internet"));
-    QCOMPARE(children[3]->name(), QString("Homebanking"));
-    QCOMPARE(children[4]->name(), QString("General"));
-    QCOMPARE(children[5]->name(), QString("eMail"));
+    QCOMPARE(children[0]->name(), QStringLiteral("Windows"));
+    QCOMPARE(children[1]->name(), QStringLiteral("Network"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Internet"));
+    QCOMPARE(children[3]->name(), QStringLiteral("Homebanking"));
+    QCOMPARE(children[4]->name(), QStringLiteral("General"));
+    QCOMPARE(children[5]->name(), QStringLiteral("eMail"));
     subChildren = internetGroup->children();
-    QCOMPARE(subChildren[0]->name(), QString("Amazon"));
-    QCOMPARE(subChildren[1]->name(), QString("eBay"));
-    QCOMPARE(subChildren[2]->name(), QString("Facebook"));
-    QCOMPARE(subChildren[3]->name(), QString("Google"));
+    QCOMPARE(subChildren[0]->name(), QStringLiteral("Amazon"));
+    QCOMPARE(subChildren[1]->name(), QStringLiteral("eBay"));
+    QCOMPARE(subChildren[2]->name(), QStringLiteral("Facebook"));
+    QCOMPARE(subChildren[3]->name(), QStringLiteral("Google"));
 
     m_dbWidget->groupView()->setCurrentGroup(rootGroup);
     triggerAction("actionGroupSortAsc");
     m_dbWidget->groupView()->setCurrentGroup(internetGroup);
     triggerAction("actionGroupSortDesc");
     children = rootGroup->children();
-    QCOMPARE(children[0]->name(), QString("eMail"));
-    QCOMPARE(children[1]->name(), QString("General"));
-    QCOMPARE(children[2]->name(), QString("Homebanking"));
-    QCOMPARE(children[3]->name(), QString("Internet"));
-    QCOMPARE(children[4]->name(), QString("Network"));
-    QCOMPARE(children[5]->name(), QString("Windows"));
+    QCOMPARE(children[0]->name(), QStringLiteral("eMail"));
+    QCOMPARE(children[1]->name(), QStringLiteral("General"));
+    QCOMPARE(children[2]->name(), QStringLiteral("Homebanking"));
+    QCOMPARE(children[3]->name(), QStringLiteral("Internet"));
+    QCOMPARE(children[4]->name(), QStringLiteral("Network"));
+    QCOMPARE(children[5]->name(), QStringLiteral("Windows"));
     subChildren = internetGroup->children();
-    QCOMPARE(subChildren[0]->name(), QString("Google"));
-    QCOMPARE(subChildren[1]->name(), QString("Facebook"));
-    QCOMPARE(subChildren[2]->name(), QString("eBay"));
-    QCOMPARE(subChildren[3]->name(), QString("Amazon"));
+    QCOMPARE(subChildren[0]->name(), QStringLiteral("Google"));
+    QCOMPARE(subChildren[1]->name(), QStringLiteral("Facebook"));
+    QCOMPARE(subChildren[2]->name(), QStringLiteral("eBay"));
+    QCOMPARE(subChildren[3]->name(), QStringLiteral("Amazon"));
 }
 
 void TestGui::testTrayRestoreHide()
@@ -2100,7 +2100,7 @@ void TestGui::checkStatusBarText(const QString& textFragment)
     QApplication::processEvents();
     QVERIFY(m_statusBarLabel->isVisible());
     QTRY_VERIFY2(m_statusBarLabel->text().startsWith(textFragment),
-                 qPrintable(QString("'%1' doesn't start with '%2'").arg(m_statusBarLabel->text(), textFragment)));
+                 qPrintable(QStringLiteral("'%1' doesn't start with '%2'").arg(m_statusBarLabel->text(), textFragment)));
 }
 
 void TestGui::triggerAction(const QString& name)

--- a/tests/gui/TestGuiBrowser.cpp
+++ b/tests/gui/TestGuiBrowser.cpp
@@ -80,7 +80,7 @@ void TestGuiBrowser::initTestCase()
 void TestGuiBrowser::init()
 {
     m_dbFile.reset(new TemporaryFile());
-    m_dbFile->copyFromFile(QString(KEEPASSX_TEST_DATA_DIR).append("/NewDatabaseBrowser.kdbx"));
+    m_dbFile->copyFromFile(QStringLiteral(KEEPASSX_TEST_DATA_DIR).append("/NewDatabaseBrowser.kdbx"));
 
     // make sure window is activated or focus tests may fail
     m_mainWindow->activateWindow();
@@ -231,18 +231,18 @@ void TestGuiBrowser::testGetDatabaseGroups()
     auto groups = result["groups"].toArray();
     auto first = groups.at(0);
     auto children = first.toObject()["children"].toArray();
-    QCOMPARE(first.toObject()["name"].toString(), QString("NewDatabase"));
+    QCOMPARE(first.toObject()["name"].toString(), QStringLiteral("NewDatabase"));
     QCOMPARE(children.size(), 6);
 
     auto firstChild = children.at(0).toObject();
     auto secondChild = children.at(1).toObject();
-    QCOMPARE(firstChild["name"].toString(), QString("General"));
-    QCOMPARE(secondChild["name"].toString(), QString("Windows"));
+    QCOMPARE(firstChild["name"].toString(), QStringLiteral("General"));
+    QCOMPARE(secondChild["name"].toString(), QStringLiteral("Windows"));
 
     auto subGroups = firstChild["children"].toArray();
     QCOMPARE(subGroups.count(), 1);
     auto subGroupObj = subGroups.at(0).toObject();
-    QCOMPARE(subGroupObj["name"].toString(), QString("SubGroup"));
+    QCOMPARE(subGroupObj["name"].toString(), QStringLiteral("SubGroup"));
 }
 
 void TestGuiBrowser::triggerAction(const QString& name)

--- a/tests/gui/TestGuiFdoSecrets.cpp
+++ b/tests/gui/TestGuiFdoSecrets.cpp
@@ -967,7 +967,7 @@ void TestGuiFdoSecrets::testCollectionDelete()
     auto args = spyPromptCompleted.takeFirst();
     COMPARE(args.count(), 2);
     COMPARE(args.at(0).toBool(), false);
-    COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QStringLiteral(""));
+    COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QString());
 
     // however, the object should already be taken down from dbus
     {
@@ -1017,7 +1017,7 @@ void TestGuiFdoSecrets::testCollectionDeleteConcurrent()
         auto args = spyPromptCompleted.takeFirst();
         COMPARE(args.count(), 2);
         COMPARE(args.at(0).toBool(), false);
-        COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QStringLiteral(""));
+        COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QString());
     }
 
     VERIFY(waitForSignal(spyPromptCompleted2, 1));
@@ -1025,7 +1025,7 @@ void TestGuiFdoSecrets::testCollectionDeleteConcurrent()
         auto args = spyPromptCompleted2.takeFirst();
         COMPARE(args.count(), 2);
         COMPARE(args.at(0).toBool(), false);
-        COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QStringLiteral(""));
+        COMPARE(args.at(1).value<QDBusVariant>().variant().toString(), QString());
     }
 
     {
@@ -1407,7 +1407,7 @@ void TestGuiFdoSecrets::testItemSecret()
     {
         auto encrypted = encryptPassword(expected, APPLICATION_OCTET_STREAM, sess);
         DBUS_VERIFY(item->SetSecret(encrypted));
-        COMPARE(entry->password(), QStringLiteral(""));
+        COMPARE(entry->password(), QString());
     }
     {
         DBUS_GET(encrypted, item->GetSecret(QDBusObjectPath(sess->path())));
@@ -1450,7 +1450,7 @@ void TestGuiFdoSecrets::testItemDelete()
     auto args = spyPromptCompleted.takeFirst();
     COMPARE(args.count(), 2);
     COMPARE(args.at(0).toBool(), false);
-    COMPARE(args.at(1).toString(), QStringLiteral(""));
+    COMPARE(args.at(1).toString(), QString());
 
     VERIFY(waitForSignal(spyItemDeleted, 1));
     args = spyItemDeleted.takeFirst();


### PR DESCRIPTION
According to https://www.qt.io/blog/2014/06/13/qt-weekly-13-qstringliteral, ```QStringLiteral``` is a macro that allows you to create ```QString``` objects from string literals with little to no runtime overhead. 

However, ```QString()``` outperforms ```QStringLiteral("")``` in terms of both instructions and memory.