### PR TITLE
Add GuiPrivate Qt Component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -402,7 +402,7 @@ if(WITH_COVERAGE)
 endif()
 
 # Find Qt
-set(QT_COMPONENTS Core Network Concurrent Gui Svg Widgets Test LinguistTools)
+set(QT_COMPONENTS Core Network Concurrent Gui GuiPrivate Svg Widgets Test LinguistTools)
 if(UNIX AND NOT APPLE)
     find_package(Qt6 COMPONENTS ${QT_COMPONENTS} DBus REQUIRED)
 elseif(APPLE)


### PR DESCRIPTION
Add missing GuiPrivate Qt Component which caused failure of build process

## Testing strategy
**Step 1 - Without this pull request patch**
On Fedora 43, with [RPMdevtools](https://fedoraproject.org/wiki/Rpmdevtools) and [mock builder](https://fedoraproject.org/wiki/Using_Mock_to_test_package_builds) installed.
[spec file](https://src.fedoraproject.org/fork/germano/rpms/keepassxc/blob/98fac501fc037f356a70d687566a83a522a935ab/f/keepassxc.spec)
```
$ rpmdev-setuptree
$ cd ~/rpmbuild/SPECS
$ wget https://src.fedoraproject.org/fork/germano/rpms/keepassxc/blob/98fac501fc037f356a70d687566a83a522a935ab/f/keepassxc.spec
$ cd ~/rpmbuild/SOURCES
$ wget https://github.com/varjolintu/keepassxc/archive/refs/heads/qt6_ver2.zip
$ mv qt6_ver2.zip keepassxc-qt6_ver2.zip
$ rpmbuild -bs ~/rpmbuild/SPECS/keepassxc.spec
$ mock -n -r fedora-rawhide-x86_64 ~/rpmbuild/SRPMS/keepassxc-2.8.0-1.fc43.src.rpm
```
failed with errors
```
CMake Error at src/CMakeLists.txt:369 (target_link_libraries):
  Target "keepassxc_gui" links to:
    Qt6::GuiPrivate
  but the target was not found.  Possible reasons include:
    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
CMake Error at src/autotype/xcb/CMakeLists.txt:6 (target_link_libraries):
  Target "keepassxc-autotype-xcb" links to:
    Qt6::GuiPrivate
  but the target was not found.  Possible reasons include:
    * There is a typo in the target name.
    * A find_package call is missing for an IMPORTED target.
    * An ALIAS target is missing.
-- Generating done (0.5s)
```
**complete logs**
[build_no_patch.log](https://github.com/user-attachments/files/23811157/build_no_patch.log)
[root_no_patch.log](https://github.com/user-attachments/files/23811158/root_no_patch.log)

**Step 2 - applying this pull request patch**
```
$ cd ~/rpmbuild/SOURCES
$ unzip keepassxc-qt6_ver2.zip
$ cp -R keepassxc-qt6_ver2 keepassxc-qt6_ver2-orig
$ sed -i 's/set(QT_COMPONENTS Core Network Concurrent Gui Svg Widgets Test LinguistTools)/set(QT_COMPONENTS Core Network Concurrent Gui GuiPrivate Svg Widgets Test LinguistTools)/' keepassxc-qt6_ver2/CMakeLists.txt
$ diff -urNr keepassxc-qt6_ver2-orig keepassxc-qt6_ver2 > cmake.patch
```
then adding to keepassxc.spec
```
Patch0:         cmake.patch # line number 12
%autopatch -p1 # line number 113
```
```
$ rpmbuild -bs ~/rpmbuild/SPECS/keepassxc.spec
$ mock -n -r fedora-rawhide-x86_64 ~/rpmbuild/SRPMS/keepassxc-2.8.0-1.fc43.src.rpm
```
then build process proceeds way further and fails for other reasons

**complete logs**
[build.log](https://github.com/user-attachments/files/23811159/build.log)
[root.log](https://github.com/user-attachments/files/23811160/root.log)


## Type of change
- ✅ Bug fix (non-breaking change that fixes an issue)